### PR TITLE
feat(POD-006): CLI entrypoint with --lang validation and exit-code translation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 authors = [{ name = "Juan García" }]
 dependencies = [
     "rich>=13.7",
+    "typer>=0.25.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
     "typer>=0.25.0",
 ]
 
+[project.scripts]
+podcast-script = "podcast_script.cli:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -228,8 +228,3 @@ def main(
         if verbosity == "debug":
             raise
         raise typer.Exit(1) from exc
-
-
-def _cli_main() -> None:
-    """Entry point for ``python -m podcast_script`` and the console-script shim."""
-    app()

--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -34,10 +34,31 @@ _DID_YOU_MEAN_MAX_DISTANCE = 2
 """Per AC-US-1.5: suggest a code only when its Levenshtein distance to the
 typo is ≤ 2. Larger distances would surface unrelated codes as 'suggestions'."""
 
+# Exit-code table required in --help by SRS §9.1 (line 430): "lists every
+# flag, the eight supported --lang codes, AND the documented exit-code
+# table (NFR-9)". Codes themselves are owned by the exception classes in
+# errors.py per ADR-0006; this is the human-readable surface.
+#
+# The leading ``\b`` is Click's "do not reflow this paragraph" marker —
+# required because Click otherwise rewraps the epilog into one run-on
+# line. Typer renders this through Click when ``rich_markup_mode=None``.
+_EXIT_CODE_EPILOG = (
+    "\b\n"
+    "Exit codes (NFR-9):\n"
+    "  0  success\n"
+    "  1  generic / unexpected internal error\n"
+    "  2  usage error (bad flags, missing/unsupported --lang, ffmpeg not on PATH)\n"
+    "  3  input I/O error (input not found, output parent missing)\n"
+    "  4  decode error (ffmpeg failed)\n"
+    "  5  model / network error\n"
+    "  6  output exists without --force"
+)
+
 app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
     pretty_exceptions_show_locals=False,
+    rich_markup_mode=None,
 )
 
 
@@ -144,7 +165,7 @@ def _run_pipeline(
     del input_path, output_path, lang, model, backend, device, force, debug
 
 
-@app.command()
+@app.command(epilog=_EXIT_CODE_EPILOG)
 def main(
     input_path: Annotated[
         Path,

--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -1,22 +1,30 @@
 """CLI entrypoint for podcast-script (POD-006).
 
-Owns the typer-based ``--lang`` validation surface. Per ADR-0006, this
-module is the *only* one that translates :class:`PodcastScriptError`
-subclasses into ``typer.Exit`` codes; stages elsewhere raise the typed
-exceptions and never call ``sys.exit`` directly.
+Owns the typer-based ``--lang`` validation surface and the ADR-0006
+exception → ``typer.Exit(code)`` translation. Per ADR-0006, this module
+is the *only* place that converts :class:`PodcastScriptError` subclasses
+into exit codes; stages elsewhere raise the typed exceptions and never
+call ``sys.exit`` directly.
 
 The ``--lang`` curated set is locked at SRS §1.7 / Q11; unknown codes are
 rejected with a "did you mean?" suggestion via Levenshtein distance ≤ 2
-(AC-US-1.5).
+(AC-US-1.5). Missing ``--lang`` (and, once POD-016 lands, no config
+fallback) is also a usage error (AC-US-4.3).
+
+The pipeline orchestrator itself lands in POD-008 (SP-2). For now,
+:func:`_run_pipeline` is a no-op so the CLI surface can be exercised
+end-to-end without the heavy ML stages.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Annotated
+
 import typer
 
-from .errors import UsageError
-
-app = typer.Typer()
+from .errors import PodcastScriptError, UsageError
+from .logging_setup import Verbosity, configure
 
 SUPPORTED_LANGS: tuple[str, ...] = ("es", "en", "pt", "fr", "de", "it", "ca", "eu")
 """The eight v1 ``--lang`` codes (SRS §1.7). Frozen for v1.0.0; expanding
@@ -25,6 +33,12 @@ this set is a SemVer-major event because it changes the CLI contract."""
 _DID_YOU_MEAN_MAX_DISTANCE = 2
 """Per AC-US-1.5: suggest a code only when its Levenshtein distance to the
 typo is ≤ 2. Larger distances would surface unrelated codes as 'suggestions'."""
+
+app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=True,
+    pretty_exceptions_show_locals=False,
+)
 
 
 def validate_lang(code: str) -> None:
@@ -44,6 +58,11 @@ def validate_lang(code: str) -> None:
     if suggestion is not None:
         raise UsageError(f"{base}; did you mean `{suggestion}`?")
     raise UsageError(base)
+
+
+def _missing_lang_error() -> UsageError:
+    supported = ", ".join(SUPPORTED_LANGS)
+    return UsageError(f"--lang is required (e.g. --lang es). Supported: {supported}")
 
 
 def _closest_supported_lang(code: str) -> str | None:
@@ -87,3 +106,130 @@ def _levenshtein(a: str, b: str) -> int:
             current.append(min(insert, delete, substitute))
         previous = current
     return previous[-1]
+
+
+def _resolve_verbosity(verbose: bool, quiet: bool, debug: bool) -> Verbosity:
+    """Map the three flag booleans to a :data:`Verbosity` label.
+
+    Mutual-exclusion enforcement and a richer matrix land in POD-014
+    (SP-5); for POD-006 we just pick the strongest signal so log output
+    behaves consistently when more than one is passed by accident.
+    """
+    if debug:
+        return "debug"
+    if verbose:
+        return "verbose"
+    if quiet:
+        return "quiet"
+    return "normal"
+
+
+def _run_pipeline(
+    *,
+    input_path: Path,
+    output_path: Path,
+    lang: str,
+    model: str,
+    backend: str | None,
+    device: str,
+    force: bool,
+    debug: bool,
+) -> None:
+    """Pipeline placeholder. Wired in POD-008 (SP-2).
+
+    Kept as a typed seam so the CLI parses, validates, and dispatches today
+    without dragging the orchestrator's heavy imports (ADR-0011) into the
+    CLI surface tests.
+    """
+    del input_path, output_path, lang, model, backend, device, force, debug
+
+
+@app.command()
+def main(
+    input_path: Annotated[
+        Path,
+        typer.Argument(
+            metavar="INPUT",
+            help="Audio file to transcribe (any format ffmpeg can decode).",
+        ),
+    ],
+    lang: Annotated[
+        str | None,
+        typer.Option("--lang", help=f"Language code. One of: {', '.join(SUPPORTED_LANGS)}."),
+    ] = None,
+    output: Annotated[
+        Path | None,
+        typer.Option(
+            "-o",
+            "--output",
+            help="Output Markdown path. Defaults to <input-stem>.md next to the input.",
+        ),
+    ] = None,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "-f", "--force", help="Overwrite an existing output file. Default refuses (exit 6)."
+        ),
+    ] = False,
+    model: Annotated[
+        str,
+        typer.Option(
+            "--model", help="Whisper model: tiny|base|small|medium|large-v3|large-v3-turbo."
+        ),
+    ] = "large-v3",
+    backend: Annotated[
+        str | None,
+        typer.Option(
+            "--backend",
+            help="Whisper backend: faster-whisper|mlx-whisper. Auto-selected by platform.",
+        ),
+    ] = None,
+    device: Annotated[
+        str, typer.Option("--device", help="Compute device: auto|cpu|cuda|mps.")
+    ] = "auto",
+    verbose: Annotated[
+        bool, typer.Option("-v", "--verbose", help="Enable debug-level logs.")
+    ] = False,
+    quiet: Annotated[
+        bool, typer.Option("-q", "--quiet", help="Suppress informational logs.")
+    ] = False,
+    debug: Annotated[
+        bool,
+        typer.Option(
+            "--debug", help="Retain intermediate artifacts in <input-stem>.debug/ (US-7)."
+        ),
+    ] = False,
+) -> None:
+    """Transcribe a podcast audio file to Markdown with music-segment markers."""
+    verbosity = _resolve_verbosity(verbose, quiet, debug)
+    log = configure(verbosity, progress=None)
+
+    try:
+        if lang is None:
+            raise _missing_lang_error()
+        validate_lang(lang)
+
+        resolved_output = output if output is not None else input_path.with_suffix(".md")
+        _run_pipeline(
+            input_path=input_path,
+            output_path=resolved_output,
+            lang=lang,
+            model=model,
+            backend=backend,
+            device=device,
+            force=force,
+            debug=debug,
+        )
+    except PodcastScriptError as exc:
+        log.error("", extra={"event": exc.event, "code": exc.exit_code, "cause": str(exc)})
+        raise typer.Exit(exc.exit_code) from exc
+    except Exception as exc:
+        log.error("", extra={"event": "internal_error", "code": 1, "cause": str(exc)})
+        if verbosity == "debug":
+            raise
+        raise typer.Exit(1) from exc
+
+
+def _cli_main() -> None:
+    """Entry point for ``python -m podcast_script`` and the console-script shim."""
+    app()

--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -1,0 +1,9 @@
+"""CLI entrypoint for podcast-script (POD-006, stub)."""
+
+from __future__ import annotations
+
+SUPPORTED_LANGS: tuple[str, ...] = ()
+
+
+def validate_lang(code: str) -> None:
+    raise NotImplementedError

--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -12,7 +12,11 @@ rejected with a "did you mean?" suggestion via Levenshtein distance ≤ 2
 
 from __future__ import annotations
 
+import typer
+
 from .errors import UsageError
+
+app = typer.Typer()
 
 SUPPORTED_LANGS: tuple[str, ...] = ("es", "en", "pt", "fr", "de", "it", "ca", "eu")
 """The eight v1 ``--lang`` codes (SRS §1.7). Frozen for v1.0.0; expanding

--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -1,9 +1,85 @@
-"""CLI entrypoint for podcast-script (POD-006, stub)."""
+"""CLI entrypoint for podcast-script (POD-006).
+
+Owns the typer-based ``--lang`` validation surface. Per ADR-0006, this
+module is the *only* one that translates :class:`PodcastScriptError`
+subclasses into ``typer.Exit`` codes; stages elsewhere raise the typed
+exceptions and never call ``sys.exit`` directly.
+
+The ``--lang`` curated set is locked at SRS §1.7 / Q11; unknown codes are
+rejected with a "did you mean?" suggestion via Levenshtein distance ≤ 2
+(AC-US-1.5).
+"""
 
 from __future__ import annotations
 
-SUPPORTED_LANGS: tuple[str, ...] = ()
+from .errors import UsageError
+
+SUPPORTED_LANGS: tuple[str, ...] = ("es", "en", "pt", "fr", "de", "it", "ca", "eu")
+"""The eight v1 ``--lang`` codes (SRS §1.7). Frozen for v1.0.0; expanding
+this set is a SemVer-major event because it changes the CLI contract."""
+
+_DID_YOU_MEAN_MAX_DISTANCE = 2
+"""Per AC-US-1.5: suggest a code only when its Levenshtein distance to the
+typo is ≤ 2. Larger distances would surface unrelated codes as 'suggestions'."""
 
 
 def validate_lang(code: str) -> None:
-    raise NotImplementedError
+    """Validate ``code`` against the curated v1 ``--lang`` set.
+
+    Raises :class:`UsageError` (exit 2) if ``code`` is not in
+    :data:`SUPPORTED_LANGS`. The error message lists all supported codes
+    and, when the typo is within Levenshtein distance 2 of a supported
+    code, appends a ``did you mean `<closest>`?`` suggestion.
+    """
+    if code in SUPPORTED_LANGS:
+        return
+
+    supported = ", ".join(SUPPORTED_LANGS)
+    suggestion = _closest_supported_lang(code)
+    base = f"unknown --lang {code!r}; supported: {supported}"
+    if suggestion is not None:
+        raise UsageError(f"{base}; did you mean `{suggestion}`?")
+    raise UsageError(base)
+
+
+def _closest_supported_lang(code: str) -> str | None:
+    """Return the closest supported code within ≤ 2 edits, or ``None``.
+
+    Ties are broken by :data:`SUPPORTED_LANGS` order — i.e. ``es`` wins
+    over ``en`` if both are equidistant — which makes the suggestion
+    deterministic across runs.
+    """
+    best: tuple[int, str] | None = None
+    for candidate in SUPPORTED_LANGS:
+        distance = _levenshtein(code, candidate)
+        if distance > _DID_YOU_MEAN_MAX_DISTANCE:
+            continue
+        if best is None or distance < best[0]:
+            best = (distance, candidate)
+    return best[1] if best is not None else None
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Standard Levenshtein edit distance.
+
+    Implemented inline rather than via a third-party ``rapidfuzz``-style
+    dep because ADR-0013 forbids new runtime deps for v1; the cost on
+    2-to-~8-character strings is negligible.
+    """
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i]
+        for j, cb in enumerate(b, start=1):
+            insert = current[j - 1] + 1
+            delete = previous[j] + 1
+            substitute = previous[j - 1] + (ca != cb)
+            current.append(min(insert, delete, substitute))
+        previous = current
+    return previous[-1]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,67 @@
+"""Tests for the ``podcast_script.cli`` module (POD-006).
+
+Covers the CLI surface that POD-006 owns: ``--lang`` curated-set validation
+(AC-US-1.5), required-``--lang`` rejection (AC-US-4.3), the typer entrypoint,
+and ADR-0006 exception → ``typer.Exit`` translation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_script.cli import SUPPORTED_LANGS, validate_lang
+from podcast_script.errors import UsageError
+
+
+class TestValidateLang:
+    """Pure-function tests for the ``--lang`` validator (AC-US-1.5)."""
+
+    @pytest.mark.parametrize("code", ["es", "en", "pt", "fr", "de", "it", "ca", "eu"])
+    def test_accepts_each_supported_code(self, code: str) -> None:
+        validate_lang(code)  # no exception
+
+    def test_supported_set_is_locked_to_eight_codes(self) -> None:
+        # SRS §1.7 / Q11 — the curated set is part of the v1 contract.
+        assert SUPPORTED_LANGS == ("es", "en", "pt", "fr", "de", "it", "ca", "eu")
+
+    def test_unknown_code_raises_usage_error(self) -> None:
+        with pytest.raises(UsageError) as exc_info:
+            validate_lang("zzzzz")
+        # ADR-0006: UsageError carries exit_code=2 + event="usage_error".
+        assert exc_info.value.exit_code == 2
+        assert exc_info.value.event == "usage_error"
+
+    def test_unknown_code_message_lists_all_eight_supported(self) -> None:
+        with pytest.raises(UsageError) as exc_info:
+            validate_lang("zzzzz")
+        message = str(exc_info.value)
+        for code in SUPPORTED_LANGS:
+            assert code in message, f"missing supported code {code!r} from message: {message!r}"
+
+    def test_unknown_code_with_no_close_match_omits_suggestion(self) -> None:
+        with pytest.raises(UsageError) as exc_info:
+            validate_lang("zzzzz")
+        # Levenshtein from "zzzzz" to any 2-char code is ≥ 3, so no suggestion.
+        assert "did you mean" not in str(exc_info.value).lower()
+
+    @pytest.mark.parametrize(
+        ("typo", "expected_suggestion"),
+        [
+            ("ess", "es"),  # distance 1 (insertion)
+            ("eng", "en"),  # distance 1
+            ("eus", "eu"),  # distance 1
+            ("dee", "de"),  # distance 1
+            ("itt", "it"),  # distance 1
+        ],
+    )
+    def test_close_typo_suggests_intended_code(self, typo: str, expected_suggestion: str) -> None:
+        with pytest.raises(UsageError) as exc_info:
+            validate_lang(typo)
+        message = str(exc_info.value)
+        assert f"did you mean `{expected_suggestion}`" in message
+
+    def test_uppercased_code_is_rejected_as_unknown(self) -> None:
+        # SRS §1.7 lists lowercase codes; case-folding is not part of v1
+        # (Q11 deliberately scoped to a tested set, not a lookup table).
+        with pytest.raises(UsageError):
+            validate_lang("ES")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,29 @@ class TestCliGrammarSurface:
         result = runner.invoke(app, [str(input_file), "-l", "es"])
         assert result.exit_code != 0
 
+    def test_help_lists_locked_grammar_surface(self, runner: CliRunner) -> None:
+        # SRS §9.1 + Q17 lock the public CLI grammar for v1.0.0. This test
+        # is the regression net: a typer upgrade that quietly drops or
+        # renames a flag, or removes a short alias, should fail here.
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        for long_flag in (
+            "--lang",
+            "--output",
+            "--force",
+            "--model",
+            "--backend",
+            "--device",
+            "--verbose",
+            "--quiet",
+            "--debug",
+        ):
+            assert long_flag in result.stdout, f"missing {long_flag} from --help"
+        for short_alias in ("-o", "-f", "-v", "-q"):
+            assert short_alias in result.stdout, f"missing short alias {short_alias} from --help"
+        for code in SUPPORTED_LANGS:
+            assert code in result.stdout, f"missing supported lang code {code!r} from --help"
+
     def test_help_includes_nfr9_exit_code_table(self, runner: CliRunner) -> None:
         # SRS §9.1 (line 430) requires --help to list "every flag, the eight
         # supported --lang codes, AND the documented exit-code table (NFR-9)".

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from podcast_script.cli import SUPPORTED_LANGS, app, validate_lang
 from podcast_script.errors import UsageError
 
 
-@pytest.fixture()
+@pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()
 
@@ -92,9 +92,7 @@ class TestValidateLang:
 class TestCliMissingLang:
     """AC-US-4.3 — no ``--lang`` flag and (in POD-006) no config layer yet."""
 
-    def test_missing_lang_exits_with_code_2(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_missing_lang_exits_with_code_2(self, runner: CliRunner, tmp_path: Path) -> None:
         input_file = _touch(tmp_path, "episode.mp3")
         result = runner.invoke(app, [str(input_file)])
         assert result.exit_code == 2
@@ -114,9 +112,7 @@ class TestCliMissingLang:
 class TestCliLangValidationSurface:
     """AC-US-1.5 wired through the typer surface (not just the pure validator)."""
 
-    def test_unknown_lang_exits_with_code_2(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_unknown_lang_exits_with_code_2(self, runner: CliRunner, tmp_path: Path) -> None:
         input_file = _touch(tmp_path, "episode.mp3")
         result = runner.invoke(app, [str(input_file), "--lang", "ja"])
         assert result.exit_code == 2
@@ -130,11 +126,11 @@ class TestCliLangValidationSurface:
         assert "did you mean `es`" in result.stderr
 
     def test_unknown_lang_emits_logfmt_event_usage_error(
-        self, runner: CliRunner, tmp_path: pytest.TempPathFactory
+        self, runner: CliRunner, tmp_path: Path
     ) -> None:
         # ADR-0006 + ADR-0008: the CLI catch-and-translate logs the
         # exception's ``event`` token so operators can grep one fixed key.
-        input_file = _touch(tmp_path, "episode.mp3")  # type: ignore[arg-type]
+        input_file = _touch(tmp_path, "episode.mp3")
         result = runner.invoke(app, [str(input_file), "--lang", "zzzzz"])
         assert "event=usage_error" in result.stderr
         assert "level=error" in result.stderr
@@ -147,13 +143,11 @@ class TestCliGrammarSurface:
     each flag does its job yet.
     """
 
-    def test_locked_short_flags_are_accepted(
-        self, runner: CliRunner, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_locked_short_flags_are_accepted(self, runner: CliRunner, tmp_path: Path) -> None:
         # SRS §9.1 / Q17 — ``-o``, ``-f``, ``-v``, ``-q`` are the only short
         # aliases. We just need the parser to accept them; downstream tasks
         # exercise the actual behaviour.
-        input_file = _touch(tmp_path, "episode.mp3")  # type: ignore[arg-type]
+        input_file = _touch(tmp_path, "episode.mp3")
         output_file = input_file.with_suffix(".md")
         result = runner.invoke(
             app,
@@ -162,17 +156,15 @@ class TestCliGrammarSurface:
         assert result.exit_code == 0, f"expected 0 got {result.exit_code}; stderr={result.stderr!r}"
 
     def test_unknown_short_flag_for_lang_is_rejected(
-        self, runner: CliRunner, tmp_path: pytest.TempPathFactory
+        self, runner: CliRunner, tmp_path: Path
     ) -> None:
         # SRS §9.1 / Q17 — ``-l`` is *not* an alias for ``--lang``; only
         # the four high-traffic options have shorts.
-        input_file = _touch(tmp_path, "episode.mp3")  # type: ignore[arg-type]
+        input_file = _touch(tmp_path, "episode.mp3")
         result = runner.invoke(app, [str(input_file), "-l", "es"])
         assert result.exit_code != 0
 
-    def test_long_only_flags_are_accepted(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_long_only_flags_are_accepted(self, runner: CliRunner, tmp_path: Path) -> None:
         input_file = _touch(tmp_path, "episode.mp3")
         result = runner.invoke(
             app,
@@ -190,5 +182,3 @@ class TestCliGrammarSurface:
             ],
         )
         assert result.exit_code == 0, f"stderr={result.stderr!r}"
-
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,24 @@ and ADR-0006 exception → ``typer.Exit`` translation.
 
 from __future__ import annotations
 
-import pytest
+from pathlib import Path
 
-from podcast_script.cli import SUPPORTED_LANGS, validate_lang
+import pytest
+from typer.testing import CliRunner
+
+from podcast_script.cli import SUPPORTED_LANGS, app, validate_lang
 from podcast_script.errors import UsageError
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _touch(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"")
+    return p
 
 
 class TestValidateLang:
@@ -73,3 +87,108 @@ class TestValidateLang:
         # (Q11 deliberately scoped to a tested set, not a lookup table).
         with pytest.raises(UsageError):
             validate_lang("ES")
+
+
+class TestCliMissingLang:
+    """AC-US-4.3 — no ``--lang`` flag and (in POD-006) no config layer yet."""
+
+    def test_missing_lang_exits_with_code_2(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(app, [str(input_file)])
+        assert result.exit_code == 2
+
+    def test_missing_lang_message_states_required_and_lists_codes(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(app, [str(input_file)])
+        stderr = result.stderr
+        assert "--lang" in stderr
+        assert "required" in stderr.lower()
+        for code in SUPPORTED_LANGS:
+            assert code in stderr, f"missing supported code {code!r} from stderr: {stderr!r}"
+
+
+class TestCliLangValidationSurface:
+    """AC-US-1.5 wired through the typer surface (not just the pure validator)."""
+
+    def test_unknown_lang_exits_with_code_2(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(app, [str(input_file), "--lang", "ja"])
+        assert result.exit_code == 2
+
+    def test_unknown_lang_message_has_did_you_mean_when_close(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(app, [str(input_file), "--lang", "ess"])
+        assert result.exit_code == 2
+        assert "did you mean `es`" in result.stderr
+
+    def test_unknown_lang_emits_logfmt_event_usage_error(
+        self, runner: CliRunner, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        # ADR-0006 + ADR-0008: the CLI catch-and-translate logs the
+        # exception's ``event`` token so operators can grep one fixed key.
+        input_file = _touch(tmp_path, "episode.mp3")  # type: ignore[arg-type]
+        result = runner.invoke(app, [str(input_file), "--lang", "zzzzz"])
+        assert "event=usage_error" in result.stderr
+        assert "level=error" in result.stderr
+
+
+class TestCliGrammarSurface:
+    """SRS §9.1 grammar — POD-006 locks the *parser* surface; pipeline-level
+    effects of these flags are wired in subsequent SP-1..SP-5 tasks. The
+    point here is that the grammar is rejected/accepted as defined, not that
+    each flag does its job yet.
+    """
+
+    def test_locked_short_flags_are_accepted(
+        self, runner: CliRunner, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        # SRS §9.1 / Q17 — ``-o``, ``-f``, ``-v``, ``-q`` are the only short
+        # aliases. We just need the parser to accept them; downstream tasks
+        # exercise the actual behaviour.
+        input_file = _touch(tmp_path, "episode.mp3")  # type: ignore[arg-type]
+        output_file = input_file.with_suffix(".md")
+        result = runner.invoke(
+            app,
+            [str(input_file), "--lang", "es", "-o", str(output_file), "-f", "-v"],
+        )
+        assert result.exit_code == 0, f"expected 0 got {result.exit_code}; stderr={result.stderr!r}"
+
+    def test_unknown_short_flag_for_lang_is_rejected(
+        self, runner: CliRunner, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        # SRS §9.1 / Q17 — ``-l`` is *not* an alias for ``--lang``; only
+        # the four high-traffic options have shorts.
+        input_file = _touch(tmp_path, "episode.mp3")  # type: ignore[arg-type]
+        result = runner.invoke(app, [str(input_file), "-l", "es"])
+        assert result.exit_code != 0
+
+    def test_long_only_flags_are_accepted(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(
+            app,
+            [
+                str(input_file),
+                "--lang",
+                "es",
+                "--model",
+                "tiny",
+                "--backend",
+                "faster-whisper",
+                "--device",
+                "cpu",
+                "--debug",
+            ],
+        )
+        assert result.exit_code == 0, f"stderr={result.stderr!r}"
+
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,21 @@ class TestCliGrammarSurface:
         result = runner.invoke(app, [str(input_file), "-l", "es"])
         assert result.exit_code != 0
 
+    def test_help_includes_nfr9_exit_code_table(self, runner: CliRunner) -> None:
+        # SRS §9.1 (line 430) requires --help to list "every flag, the eight
+        # supported --lang codes, AND the documented exit-code table (NFR-9)".
+        # The flags + lang codes already render via typer; this asserts the
+        # exit-code table is also present so v1.0.0 ships §9.1-compliant.
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "Exit codes" in result.stdout
+        for code in ("0", "1", "2", "3", "4", "5", "6"):
+            assert code in result.stdout, f"missing exit code {code} from --help"
+        # Spot-check the categories from NFR-9 are present so the table is
+        # human-readable, not just a column of digits.
+        assert "usage" in result.stdout.lower()
+        assert "decode" in result.stdout.lower()
+
     def test_long_only_flags_are_accepted(self, runner: CliRunner, tmp_path: Path) -> None:
         input_file = _touch(tmp_path, "episode.mp3")
         result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,11 +47,11 @@ class TestValidateLang:
     @pytest.mark.parametrize(
         ("typo", "expected_suggestion"),
         [
-            ("ess", "es"),  # distance 1 (insertion)
-            ("eng", "en"),  # distance 1
-            ("eus", "eu"),  # distance 1
-            ("dee", "de"),  # distance 1
-            ("itt", "it"),  # distance 1
+            ("ess", "es"),  # distance 1 (insertion); unambiguous
+            ("eng", "en"),  # distance 1; unambiguous
+            ("frr", "fr"),  # distance 1; unambiguous
+            ("dee", "de"),  # distance 1; unambiguous
+            ("itt", "it"),  # distance 1; unambiguous
         ],
     )
     def test_close_typo_suggests_intended_code(self, typo: str, expected_suggestion: str) -> None:
@@ -59,6 +59,14 @@ class TestValidateLang:
             validate_lang(typo)
         message = str(exc_info.value)
         assert f"did you mean `{expected_suggestion}`" in message
+
+    def test_equidistant_ties_break_by_supported_set_order(self) -> None:
+        # "eus" is distance 1 from both "es" (delete 'u') and "eu"
+        # (delete 's'). Without a semantic tie-breaker, we pick the first
+        # of SUPPORTED_LANGS so the message is deterministic.
+        with pytest.raises(UsageError) as exc_info:
+            validate_lang("eus")
+        assert "did you mean `es`" in str(exc_info.value)
 
     def test_uppercased_code_is_rejected_as_unknown(self) -> None:
         # SRS §1.7 lists lowercase codes; case-folding is not part of v1

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,27 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -190,6 +211,7 @@ version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -200,7 +222,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "rich", specifier = ">=13.7" }]
+requires-dist = [
+    { name = "rich", specifier = ">=13.7" },
+    { name = "typer", specifier = ">=0.25.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -270,6 +295,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Locks the SRS §9.1 CLI grammar surface: `<input>` positional + `--lang` (curated 8-code set) + `-o/--output`, `-f/--force`, `--model`, `--backend`, `--device`, `-v/--verbose`, `-q/--quiet`, `--debug`. Short aliases limited to `-o/-f/-v/-q` per Q17.
- Implements ADR-0006 catch-and-translate: `UsageError` → `typer.Exit(2)`, with the matching `event=usage_error` logfmt line emitted by the existing `logging_setup` (POD-003).
- `podcast-script` is now invokable as a console script after `uv sync` (`[project.scripts]`).
- Closes POD-006 (story US-1, sprint SP-1 of PROJECT_PLAN.md).

## Acceptance criteria satisfied
- [x] **AC-US-1.5** — unknown `--lang` exits 2 with the supported-list message and a ``did you mean `<closest>`?`` suggestion when Levenshtein ≤ 2; covered by `tests/test_cli.py::TestValidateLang` (8 tests) and `tests/test_cli.py::TestCliLangValidationSurface` (3 tests).
- [x] **AC-US-4.3** — missing `--lang` exits 2 with the required-flag message + 8 supported codes; covered by `tests/test_cli.py::TestCliMissingLang` (2 tests). NB: the config-file fallback layer (POD-016, SP-4) will eventually inject `lang` from `~/.config/podcast-script/config.toml`; AC-US-4.3 stays satisfied because POD-016 will run upstream of `validate_lang`.

## Out of scope (deferred per PROJECT_PLAN.md)
- Decode (POD-007), atomic write (POD-009), pipeline orchestrator (POD-008) — `_run_pipeline` is a typed no-op seam in this PR.
- Config-file precedence (POD-016, SP-4), `--force` semantics (POD-022/023, SP-4), `--debug` artifact directory (POD-024, SP-6).
- Verbosity matrix mutual exclusion (POD-014, SP-5) — `_resolve_verbosity` picks the strongest signal for now and will be replaced.

## Definition of Done (per PROJECT_PLAN.md §3.2)
- [x] `pytest` green locally — 61 tests pass (was 34 before this PR).
- [x] `ruff check` clean.
- [x] `ruff format --check` clean.
- [x] `mypy --strict` clean (no issues found in 9 source files).
- [ ] CI matrix (Ubuntu + macOS) — POD-004 not yet shipped, so there is no CI workflow yet. Local gate stands in until POD-004 lands.
- [x] AC tests verify both AC-US-1.5 and AC-US-4.3.
- [N/A] README / CHANGELOG — POD-006 is internal scaffolding (the pipeline is still stubbed); README is POD-036 (SP-7) and CHANGELOG is POD-038 (SP-8).
- [N/A] Smoke test on \`examples/sample.mp3\` — \`examples/sample.mp3\` is sourced in POD-026 (SP-7); the SP-1 smoke test arrives once POD-007/008/009 land.

## Test plan
- [x] \`uv run pytest\` — 61 pass.
- [x] \`uv run podcast-script --help\` renders the locked grammar (verified locally).
- [x] \`uv run podcast-script /tmp/x.mp3 --lang ess 2>&1\` shows the did-you-mean suggestion.
- [x] \`uv run podcast-script /tmp/x.mp3 2>&1\` shows the missing-flag message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)