### PR TITLE
ci(POD-004): GitHub Actions ci.yml — Ubuntu + macOS-14 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ffmpeg (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
+      - name: Install ffmpeg (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ffmpeg
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Lint (ruff check)
+        run: uv run ruff check
+
+      - name: Format check (ruff format)
+        run: uv run ruff format --check
+
+      - name: Type check (mypy --strict)
+        run: uv run mypy
+
+      - name: Tests (pytest)
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` per `PROJECT_BRIEF.md` §9 and `PROJECT_PLAN.md` §6 SP-1 cross-cutting.
- Closes POD-004 (cross-cutting infrastructure, scheduled in SP-1, 2 sub-pt).
- This is the first PR that will exercise the new workflow on itself — its own green run is the acceptance gate.

## What ships
- **Triggers:** every PR + push to `main`.
- **Matrix:** `ubuntu-latest` + `macos-14`, `fail-fast: false` (each OS reports independently).
- **Python:** 3.12 (pinned via `astral-sh/setup-uv`).
- **Steps:** checkout → install ffmpeg (apt-get / brew) → install uv (with cache) → `uv sync --frozen` → `uv run ruff check` → `uv run ruff format --check` → `uv run mypy` → `uv run pytest`.

## Acceptance criteria
- [x] `ci.yml` lives at `.github/workflows/ci.yml`.
- [x] Triggers on PRs + push to `main`.
- [x] Matrix: `ubuntu-latest` + `macos-14` (R-13: pin `macos-14`, not `macos-latest`).
- [x] Python 3.12.
- [x] All seven verification steps present in the order brief §9 specifies.
- [ ] Both OSes pass — verified by this PR's own CI run.

## Constraints applied
- **PROJECT_PLAN.md §1.2** — Python 3.12+ frozen.
- **PROJECT_BRIEF.md §9** — exact step list (ffmpeg install, setup-uv, uv sync, ruff check, ruff format --check, mypy, pytest).
- **R-13 mitigation** — `macos-14` pinned now (the plan defers explicit pinning to SP-8 but pinning early is free).
- **DoD §3.2** — going forward, every PR's CI matrix must be green to be mergeable; this PR is the bootstrap.

## Out of scope (deferred per plan)
- **SPK-1** — combined TF + MLX + faster-whisper install validation on Apple Silicon. Off-velocity spike, separate task.
- **POD-005** — Dependabot + `pip-audit` weekly cron. Scheduled for SP-8.
- **Heavy ML integration tests** on `examples/sample.mp3` — those land in SP-3 (POD-031, faster-whisper) and SP-4 (mlx-whisper) once the backends exist.
- **Coverage upload** — DoD §3.2 names a coverage target but no upload requirement; deferred.

## Test plan
- [x] Local lint clean: `uv run ruff check`
- [x] Local format clean: `uv run ruff format --check`
- [x] Local type-check clean: `uv run mypy`
- [x] Local tests green: `uv run pytest` (71 passed in 0.28s on macOS)
- [x] YAML structure validated locally (1 job, 2 OS matrix entries, 9 steps)
- [ ] **CI on this PR** runs both Ubuntu and macOS-14 jobs and both pass

## Definition of Done
- [x] Code merged candidate: trunk-based feature branch, squash-merge target
- [x] Tests green locally
- [ ] CI matrix green (verified by this PR)
- [x] No README/CHANGELOG update needed — CI is non-user-facing per DoD §3.2; full README pass is POD-036 in SP-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)