### PR TITLE
feat(POD-009): atomic_write helper via tempfile + os.replace

### DIFF
--- a/docs/adr/0005-atomic-output-via-temp-and-rename.md
+++ b/docs/adr/0005-atomic-output-via-temp-and-rename.md
@@ -21,6 +21,8 @@ Write the transcript via a **temp file in the same directory as the resolved out
 4. After render produces the full Markdown string, open a temp file with `tempfile.NamedTemporaryFile(dir=final.parent, prefix=final.stem + ".", suffix=".md.tmp", delete=False)`, write, fsync (best-effort), close.
 5. `os.replace(tmp_path, final)` — atomic on POSIX when source and destination are on the same filesystem; this is guaranteed because the temp file is created in `final.parent`.
 6. On any exception between step 4 and step 5, the temp file is `unlink()`-ed in a `finally` block; the pre-existing `final` (if any) is unchanged.
+7. After a successful `os.replace`, open `final.parent` and `os.fsync(dir_fd)` so the rename's directory-entry change is durable across a power loss. Best-effort, matching step 4's file-fsync policy: failures (e.g. on filesystems that don't support directory fsync) are swallowed. Added in v1.1 (PR #7) as defense-in-depth; NFR-5 was already satisfied without it.
+8. If `final` existed before the rename, capture its mode via `os.stat(final).st_mode` before step 4 and `os.chmod(final, prior_mode)` after step 5. `tempfile.NamedTemporaryFile` creates the temp at `0o600`, so without restoration a `--force` rerun would silently demote a user's `chmod 644 episode.md`. Added in v1.1 (PR #7).
 
 The temp filename includes the input stem and a `.tmp` suffix so a stray temp file (left after a process kill -9, where Python `finally` doesn't run) is recognizable and ignorable by humans.
 
@@ -33,8 +35,9 @@ The same-directory-as-output rule is required for atomicity: cross-filesystem re
 
 ## Consequences
 - **Positive:** atomic guarantee holds on POSIX; existing `episode.md` is never destroyed by a failed run; users iterating on flags don't lose previously hand-edited transcripts (US-6).
+- **Positive (v1.1):** prior file mode is preserved across `--force` reruns (step 8); the rename itself is durable across power loss (step 7).
 - **Negative:** rare-case clutter — a `kill -9` mid-write may leave `<input_stem>.<rand>.md.tmp` next to the input; humans recognize and delete. We do not auto-clean stale tmp files on subsequent runs (out of scope).
-- **Neutral:** `fsync` before rename is best-effort; we don't fail the run if `fsync` errors (rare on local FS).
+- **Neutral:** `fsync` before rename is best-effort; we don't fail the run if `fsync` errors (rare on local FS). Same policy applies to the parent-directory fsync added in step 7.
 
 ## Related
 - ADR-0002 (Pipeline orchestrator — owns the temp+rename code)

--- a/src/podcast_script/atomic_write.py
+++ b/src/podcast_script/atomic_write.py
@@ -8,6 +8,7 @@ orchestrator (POD-008, SP-2) is the only intended caller.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import tempfile
 from pathlib import Path
@@ -23,28 +24,23 @@ def atomic_write(path: Path, content: str) -> None:
     temp file is removed and any prior file at ``path`` is untouched.
     """
     payload = content.encode("utf-8")
-
-    tmp = tempfile.NamedTemporaryFile(
-        mode="wb",
-        dir=path.parent,
-        prefix=path.stem + ".",
-        suffix=".md.tmp",
-        delete=False,
-    )
-    tmp_path = Path(tmp.name)
+    tmp_path: Path | None = None
     renamed = False
     try:
-        try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            prefix=path.stem + ".",
+            suffix=".md.tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
             tmp.write(payload)
             tmp.flush()
-            try:
+            with contextlib.suppress(OSError):
                 os.fsync(tmp.fileno())
-            except OSError:
-                pass
-        finally:
-            tmp.close()
         os.replace(tmp_path, path)
         renamed = True
     finally:
-        if not renamed:
+        if not renamed and tmp_path is not None:
             tmp_path.unlink(missing_ok=True)

--- a/src/podcast_script/atomic_write.py
+++ b/src/podcast_script/atomic_write.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import stat
 import tempfile
 from pathlib import Path
 
@@ -24,6 +25,10 @@ def atomic_write(path: Path, content: str) -> None:
     temp file is removed and any prior file at ``path`` is untouched.
     """
     payload = content.encode("utf-8")
+    prior_mode: int | None = None
+    with contextlib.suppress(FileNotFoundError):
+        prior_mode = stat.S_IMODE(path.stat().st_mode)
+
     tmp_path: Path | None = None
     renamed = False
     try:
@@ -44,3 +49,6 @@ def atomic_write(path: Path, content: str) -> None:
     finally:
         if not renamed and tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
+
+    if prior_mode is not None:
+        os.chmod(path, prior_mode)

--- a/src/podcast_script/atomic_write.py
+++ b/src/podcast_script/atomic_write.py
@@ -50,5 +50,24 @@ def atomic_write(path: Path, content: str) -> None:
         if not renamed and tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
 
+    _fsync_directory_best_effort(path.parent)
+
     if prior_mode is not None:
         os.chmod(path, prior_mode)
+
+
+def _fsync_directory_best_effort(directory: Path) -> None:
+    """Flush ``directory``'s metadata so the preceding rename survives a
+    power loss. Best-effort: any ``OSError`` (e.g. on filesystems that don't
+    support directory fsync) is swallowed, mirroring the file-fsync policy
+    in ADR-0005 §Consequences.
+    """
+    try:
+        dir_fd = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        with contextlib.suppress(OSError):
+            os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)

--- a/src/podcast_script/atomic_write.py
+++ b/src/podcast_script/atomic_write.py
@@ -32,14 +32,19 @@ def atomic_write(path: Path, content: str) -> None:
         delete=False,
     )
     tmp_path = Path(tmp.name)
+    renamed = False
     try:
-        tmp.write(payload)
-        tmp.flush()
         try:
-            os.fsync(tmp.fileno())
-        except OSError:
-            pass
+            tmp.write(payload)
+            tmp.flush()
+            try:
+                os.fsync(tmp.fileno())
+            except OSError:
+                pass
+        finally:
+            tmp.close()
+        os.replace(tmp_path, path)
+        renamed = True
     finally:
-        tmp.close()
-
-    os.replace(tmp_path, path)
+        if not renamed:
+            tmp_path.unlink(missing_ok=True)

--- a/src/podcast_script/atomic_write.py
+++ b/src/podcast_script/atomic_write.py
@@ -1,13 +1,45 @@
 """Atomic temp-then-rename writer (POD-009 / ADR-0005).
 
-Stub — implementation lands in the green step of the TDD cycle.
+Owns the all-or-nothing write contract behind NFR-5 and AC-US-6.3: the
+final Markdown either lands in full at the resolved output path, or the
+path stays exactly as it was before the run started. The pipeline
+orchestrator (POD-008, SP-2) is the only intended caller.
 """
 
 from __future__ import annotations
 
+import os
+import tempfile
 from pathlib import Path
 
 
 def atomic_write(path: Path, content: str) -> None:
-    """Atomically write ``content`` (UTF-8) to ``path``."""
-    raise NotImplementedError
+    """Atomically write ``content`` (UTF-8) to ``path``.
+
+    A temp file is created in ``path.parent`` (so the rename is on the
+    same filesystem and therefore atomic on POSIX per ADR-0005), the
+    payload is written and ``fsync``-ed best-effort, then ``os.replace``
+    promotes it to ``path``. If anything fails before the rename, the
+    temp file is removed and any prior file at ``path`` is untouched.
+    """
+    payload = content.encode("utf-8")
+
+    tmp = tempfile.NamedTemporaryFile(
+        mode="wb",
+        dir=path.parent,
+        prefix=path.stem + ".",
+        suffix=".md.tmp",
+        delete=False,
+    )
+    tmp_path = Path(tmp.name)
+    try:
+        tmp.write(payload)
+        tmp.flush()
+        try:
+            os.fsync(tmp.fileno())
+        except OSError:
+            pass
+    finally:
+        tmp.close()
+
+    os.replace(tmp_path, path)

--- a/src/podcast_script/atomic_write.py
+++ b/src/podcast_script/atomic_write.py
@@ -1,0 +1,13 @@
+"""Atomic temp-then-rename writer (POD-009 / ADR-0005).
+
+Stub — implementation lands in the green step of the TDD cycle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Atomically write ``content`` (UTF-8) to ``path``."""
+    raise NotImplementedError

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -89,6 +89,25 @@ def test_atomic_write_leaves_no_partial_file_on_failure_NFR_5_negative(
     assert list(tmp_path.iterdir()) == []
 
 
+def test_atomic_write_preserves_prior_file_mode_on_force_rerun(
+    tmp_path: Path,
+) -> None:
+    """The mode of an existing target file is preserved across a `--force`
+    rerun. ``tempfile.NamedTemporaryFile`` creates the temp at 0o600; without
+    explicit restoration ``os.replace`` would silently demote a user's
+    ``chmod 644 episode.md`` after a successful overwrite. The orchestrator
+    relies on the helper to keep the user's chosen mode intact (per PR #7
+    review).
+    """
+    target = tmp_path / "episode.md"
+    target.write_text("prior\n", encoding="utf-8")
+    target.chmod(0o644)
+
+    atomic_write(target, "fresh transcript\n")
+
+    assert target.stat().st_mode & 0o777 == 0o644
+
+
 def test_atomic_write_creates_temp_in_target_directory_ADR_0005(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -9,12 +9,16 @@ silently drop the atomicity guarantee.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
-from podcast_script import atomic_write as atomic_write_module
 from podcast_script.atomic_write import atomic_write
+
+
+class _Boom(RuntimeError):
+    """Sentinel raised by injected failures so tests can assert the leak path."""
 
 
 def test_atomic_write_writes_complete_content_to_target_NFR_5_success(
@@ -29,3 +33,55 @@ def test_atomic_write_writes_complete_content_to_target_NFR_5_success(
     atomic_write(target, payload)
 
     assert target.read_text(encoding="utf-8") == payload
+
+
+def test_atomic_write_preserves_prior_file_on_failure_AC_US_6_3(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC-US-6.3 — if the rename fails after a `--force` run has begun, the
+    pre-existing output file at ``path`` is preserved byte-for-byte and no
+    stray ``.md.tmp`` remains in the target directory.
+
+    Failure is injected by patching ``os.replace`` so the temp file is
+    on disk but the promotion to ``path`` fails — the same window the ADR
+    mandates we recover from.
+    """
+    target = tmp_path / "episode.md"
+    prior = "# previous transcript\n\nhand-edited paragraph kept across reruns.\n"
+    target.write_text(prior, encoding="utf-8")
+
+    def boom(_src: str | os.PathLike[str], _dst: str | os.PathLike[str]) -> None:
+        raise _Boom("simulated FS error during rename")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+    with pytest.raises(_Boom):
+        atomic_write(target, "fresh transcript that must not land\n")
+
+    assert target.read_text(encoding="utf-8") == prior
+    assert [p.name for p in tmp_path.iterdir()] == [target.name], (
+        "no .md.tmp should remain after a cleaned-up failure"
+    )
+
+
+def test_atomic_write_leaves_no_partial_file_on_failure_NFR_5_negative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NFR-5 (failure path) — when no prior file exists and the rename
+    fails, the resolved output path stays absent (no partial Markdown).
+    """
+    target = tmp_path / "episode.md"
+    assert not target.exists()
+
+    def boom(_src: str | os.PathLike[str], _dst: str | os.PathLike[str]) -> None:
+        raise _Boom("simulated FS error during rename")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+    with pytest.raises(_Boom):
+        atomic_write(target, "should never appear at target\n")
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -10,7 +10,9 @@ silently drop the atomicity guarantee.
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -85,3 +87,35 @@ def test_atomic_write_leaves_no_partial_file_on_failure_NFR_5_negative(
 
     assert not target.exists()
     assert list(tmp_path.iterdir()) == []
+
+
+def test_atomic_write_creates_temp_in_target_directory_ADR_0005(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADR-0005 — the temp file MUST be created in ``path.parent`` (so the
+    rename stays on the same filesystem and remains atomic on POSIX), and
+    its name MUST embed ``path.stem`` + the ``.md.tmp`` suffix so a stray
+    temp after ``kill -9`` is recognizable to humans.
+
+    Captured via a wrapper around ``tempfile.NamedTemporaryFile`` so the
+    assertion is on the kwargs the helper passes, not on observable file
+    layout (the temp is unlinked on success or failure, leaving nothing
+    to inspect after the call).
+    """
+    captured: dict[str, Any] = {}
+    real_named_temp = tempfile.NamedTemporaryFile
+
+    def spy(*args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return real_named_temp(*args, **kwargs)
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", spy)
+
+    target = tmp_path / "episode.md"
+    atomic_write(target, "ok\n")
+
+    assert captured["dir"] == target.parent
+    assert captured["prefix"] == "episode."
+    assert captured["suffix"] == ".md.tmp"
+    assert captured["delete"] is False

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -24,6 +24,21 @@ class _Boom(RuntimeError):
     """Sentinel raised by injected failures so tests can assert the leak path."""
 
 
+@pytest.fixture
+def replace_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``os.replace`` to raise :class:`_Boom`.
+
+    Shared by every test that exercises a mid-rename failure (AC-US-6.3,
+    NFR-5 negative, etc.). Extracted from a Rule-of-Three duplication
+    flagged in PR #7 review (suggestion #3).
+    """
+
+    def boom(_src: str | os.PathLike[str], _dst: str | os.PathLike[str]) -> None:
+        raise _Boom("simulated FS error during rename")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+
 def test_atomic_write_writes_complete_content_to_target_NFR_5_success(
     tmp_path: Path,
 ) -> None:
@@ -40,24 +55,15 @@ def test_atomic_write_writes_complete_content_to_target_NFR_5_success(
 
 def test_atomic_write_preserves_prior_file_on_failure_AC_US_6_3(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    replace_raises: None,
 ) -> None:
     """AC-US-6.3 — if the rename fails after a `--force` run has begun, the
     pre-existing output file at ``path`` is preserved byte-for-byte and no
     stray ``.md.tmp`` remains in the target directory.
-
-    Failure is injected by patching ``os.replace`` so the temp file is
-    on disk but the promotion to ``path`` fails — the same window the ADR
-    mandates we recover from.
     """
     target = tmp_path / "episode.md"
     prior = "# previous transcript\n\nhand-edited paragraph kept across reruns.\n"
     target.write_text(prior, encoding="utf-8")
-
-    def boom(_src: str | os.PathLike[str], _dst: str | os.PathLike[str]) -> None:
-        raise _Boom("simulated FS error during rename")
-
-    monkeypatch.setattr(os, "replace", boom)
 
     with pytest.raises(_Boom):
         atomic_write(target, "fresh transcript that must not land\n")
@@ -70,18 +76,13 @@ def test_atomic_write_preserves_prior_file_on_failure_AC_US_6_3(
 
 def test_atomic_write_leaves_no_partial_file_on_failure_NFR_5_negative(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    replace_raises: None,
 ) -> None:
     """NFR-5 (failure path) — when no prior file exists and the rename
     fails, the resolved output path stays absent (no partial Markdown).
     """
     target = tmp_path / "episode.md"
     assert not target.exists()
-
-    def boom(_src: str | os.PathLike[str], _dst: str | os.PathLike[str]) -> None:
-        raise _Boom("simulated FS error during rename")
-
-    monkeypatch.setattr(os, "replace", boom)
 
     with pytest.raises(_Boom):
         atomic_write(target, "should never appear at target\n")

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -10,6 +10,7 @@ silently drop the atomicity guarantee.
 from __future__ import annotations
 
 import os
+import stat
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -87,6 +88,34 @@ def test_atomic_write_leaves_no_partial_file_on_failure_NFR_5_negative(
 
     assert not target.exists()
     assert list(tmp_path.iterdir()) == []
+
+
+def test_atomic_write_fsyncs_parent_directory_after_replace_ADR_0005(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADR-0005 (extended) — after a successful ``os.replace``, the parent
+    directory's metadata is ``fsync``-ed best-effort so the rename itself
+    is durable across a power loss. NFR-5 is unaffected (the rollback would
+    be to the prior file or to no file — never partial), but the parent-dir
+    fsync is defense-in-depth from PR #7 review (suggestion #2).
+    """
+    real_fsync = os.fsync
+    fsynced_kinds: list[str] = []
+
+    def spy(fd: int) -> None:
+        kind = "dir" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file"
+        fsynced_kinds.append(kind)
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", spy)
+
+    target = tmp_path / "episode.md"
+    atomic_write(target, "ok\n")
+
+    assert "dir" in fsynced_kinds, (
+        f"expected at least one fsync on the parent directory; got {fsynced_kinds!r}"
+    )
 
 
 def test_atomic_write_preserves_prior_file_mode_on_force_rerun(

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,0 +1,31 @@
+"""Tests for the atomic-write helper (POD-009 / ADR-0005).
+
+The helper is the contract that AC-US-6.3 and NFR-5 hang off: writing the
+final Markdown must be all-or-nothing. The pipeline orchestrator (POD-008,
+SP-2) is the only intended caller; these Tier-1 unit tests pin the
+behaviours the orchestrator depends on, so a future refactor cannot
+silently drop the atomicity guarantee.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from podcast_script import atomic_write as atomic_write_module
+from podcast_script.atomic_write import atomic_write
+
+
+def test_atomic_write_writes_complete_content_to_target_NFR_5_success(
+    tmp_path: Path,
+) -> None:
+    """NFR-5 (success path) — when the write completes, the resolved output
+    path contains the full content as UTF-8.
+    """
+    target = tmp_path / "episode.md"
+    payload = "# Hola\n\nepisodio de prueba — café ☕\n"
+
+    atomic_write(target, payload)
+
+    assert target.read_text(encoding="utf-8") == payload


### PR DESCRIPTION
## Summary
- Add `podcast_script.atomic_write.atomic_write(path, content)`: write Markdown via `tempfile.NamedTemporaryFile(dir=path.parent, …)` + `os.replace`, with temp-file cleanup on failure.
- Closes POD-009 (story US-1, sprint SP-1).
- Helper is ready for POD-008 (Pipeline orchestrator, SP-2) to consume; the CLI's `_run_pipeline` stub is intentionally not rewired here.

## Acceptance criteria satisfied
- [x] AC-US-6.3 — `test_atomic_write_preserves_prior_file_on_failure_AC_US_6_3`
- [x] NFR-5 (success) — `test_atomic_write_writes_complete_content_to_target_NFR_5_success`
- [x] NFR-5 (failure) — `test_atomic_write_leaves_no_partial_file_on_failure_NFR_5_negative`
- [x] ADR-0005 invariant — `test_atomic_write_creates_temp_in_target_directory_ADR_0005`

## Architectural constraints applied
- ADR-0005: temp file lives in `path.parent` (atomic POSIX rename); name is `<stem>.<rand>.md.tmp` (recognizable after `kill -9`); `fsync` best-effort; `os.replace` (not `os.rename`); cleanup on failure.
- ADR-0007: shipped as a sibling module in the flat `src/podcast_script/` package; no new subpackage.

## Test plan
- [x] `uv run --frozen pytest -q` — 75 passed
- [x] `uv run --frozen ruff check .` — clean
- [x] `uv run --frozen ruff format --check .` — clean
- [x] `uv run --frozen mypy` — strict, no issues

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target
- [x] Tests green (Tier-1 unit, no ffmpeg required)
- [x] Inline docstrings cover the contract
- [ ] README/CHANGELOG/ARCHITECTURE — deferred to SP-8 per plan §6 (POD-036/037/038)

🤖 Generated with [Claude Code](https://claude.com/claude-code)