### PR TITLE
feat(POD-021): first-run model_download notice within 1 s of process start (US-5)

### DIFF
--- a/src/podcast_script/backends/base.py
+++ b/src/podcast_script/backends/base.py
@@ -83,7 +83,17 @@ class WhisperBackend(Protocol):
 # ---------------------------------------------------------------------------
 
 
-MODEL_SIZES_GB: dict[str, float] = {}
+MODEL_SIZES_GB: dict[str, float] = {
+    "tiny": 0.075,
+    "base": 0.14,
+    "small": 0.46,
+    "medium": 1.5,
+    "large": 3.0,
+    "large-v1": 3.0,
+    "large-v2": 3.0,
+    "large-v3": 3.0,
+    "large-v3-turbo": 1.6,
+}
 """Approximate on-disk sizes for v1-supported Whisper models.
 
 Used by :func:`emit_first_run_notice_if_missing` to populate the
@@ -91,6 +101,14 @@ Used by :func:`emit_first_run_notice_if_missing` to populate the
 (ADR-0012). Values are deliberately coarse — the precise indicator is
 ``huggingface_hub``'s download progress bar that follows the notice.
 Adding a model post-v1 is a minor change; removing one is breaking.
+"""
+
+_UNKNOWN_MODEL_SIZE_GB = 1.0
+"""Fallback size used when the user passes a model name we don't track.
+
+Conservative: the user gets warned a download may be coming, then sees
+``huggingface_hub``'s real progress bar, rather than us silently letting
+a multi-GB transfer surprise them.
 """
 
 
@@ -109,7 +127,19 @@ def emit_first_run_notice_if_missing(
     (POD-030, SP-6) substitute a synthetic miss to verify the contract
     without touching the real HF cache.
 
-    Scaffold for POD-021: emits nothing until the implementation cycle
-    lands.
+    The emitted record carries the locked ADR-0012 shape: ``event``,
+    ``model``, ``size_gb``. ``size_gb`` is rendered with ``{:g}`` so
+    round numbers ship bare (``3``) and fractional sizes keep their
+    decimals (``0.075``).
     """
-    del model, is_cached, logger
+    if is_cached(model):
+        return
+    size_gb = MODEL_SIZES_GB.get(model, _UNKNOWN_MODEL_SIZE_GB)
+    logger.info(
+        "",
+        extra={
+            "event": "model_download",
+            "model": model,
+            "size_gb": f"{size_gb:g}",
+        },
+    )

--- a/src/podcast_script/backends/base.py
+++ b/src/podcast_script/backends/base.py
@@ -88,19 +88,21 @@ MODEL_SIZES_GB: dict[str, float] = {
     "base": 0.14,
     "small": 0.46,
     "medium": 1.5,
-    "large": 3.0,
-    "large-v1": 3.0,
-    "large-v2": 3.0,
     "large-v3": 3.0,
     "large-v3-turbo": 1.6,
 }
-"""Approximate on-disk sizes for v1-supported Whisper models.
+"""Approximate on-disk sizes for the v1-supported Whisper models.
 
 Used by :func:`emit_first_run_notice_if_missing` to populate the
 ``size_gb`` token of the locked ``event=model_download`` shape
 (ADR-0012). Values are deliberately coarse — the precise indicator is
 ``huggingface_hub``'s download progress bar that follows the notice.
 Adding a model post-v1 is a minor change; removing one is breaking.
+
+Older Whisper variants (``large``, ``large-v1``, ``large-v2``) are
+intentionally absent — passing one falls back to
+:data:`_UNKNOWN_MODEL_SIZE_GB` so the user still sees a notice. Adding
+them now would lock them into the v1.0.0 SemVer surface.
 """
 
 _UNKNOWN_MODEL_SIZE_GB = 1.0

--- a/src/podcast_script/backends/base.py
+++ b/src/podcast_script/backends/base.py
@@ -1,4 +1,4 @@
-"""Whisper backend Protocol surface (ADR-0003 / API-2).
+"""Whisper backend Protocol surface + first-run notice helper (ADR-0003).
 
 The :class:`Pipeline` (POD-008) depends only on this Protocol; concrete
 backends (``FasterWhisperBackend`` POD-019, ``MlxWhisperBackend`` POD-020)
@@ -7,13 +7,20 @@ inside each implementation's :meth:`WhisperBackend.load` per ADR-0011, so
 nothing in this module triggers a TF / MLX import at CLI startup.
 
 The Protocol is **internal**: SRS §9.3 explicitly does not commit it as a
-stable public API for v1.0.0. ``select_backend`` (POD-018) lands later in
-SP-3 and selects the concrete implementation by platform per ADR-0003.
+stable public API for v1.0.0. ``select_backend`` (POD-017) lands later in
+SP-4 and selects the concrete implementation by platform per ADR-0003.
+
+POD-021 adds the shared first-run download notice helper used by every
+backend's ``load()``: :func:`emit_first_run_notice_if_missing` emits the
+locked ``event=model_download`` line per ADR-0012 / AC-US-5.1 when the
+caller's injected ``is_cached`` returns ``False``. Centralising the
+emit-once logic here keeps faster + mlx mirrors free of duplication.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+import logging
+from collections.abc import Callable, Iterable
 from typing import NamedTuple, Protocol
 
 import numpy as np
@@ -69,3 +76,40 @@ class WhisperBackend(Protocol):
         the result.
         """
         ...
+
+
+# ---------------------------------------------------------------------------
+# First-run download notice (POD-021 — AC-US-5.1 / AC-US-5.2 / ADR-0012)
+# ---------------------------------------------------------------------------
+
+
+MODEL_SIZES_GB: dict[str, float] = {}
+"""Approximate on-disk sizes for v1-supported Whisper models.
+
+Used by :func:`emit_first_run_notice_if_missing` to populate the
+``size_gb`` token of the locked ``event=model_download`` shape
+(ADR-0012). Values are deliberately coarse — the precise indicator is
+``huggingface_hub``'s download progress bar that follows the notice.
+Adding a model post-v1 is a minor change; removing one is breaking.
+"""
+
+
+def emit_first_run_notice_if_missing(
+    model: str,
+    *,
+    is_cached: Callable[[str], bool],
+    logger: logging.Logger,
+) -> None:
+    """Emit the AC-US-5.1 first-run notice when ``model`` is not cached.
+
+    Backends call this from their :meth:`WhisperBackend.load` BEFORE
+    triggering the heavy library / network path so the NFR-6 1-s budget
+    holds regardless of how slow ``huggingface_hub`` is. ``is_cached`` is
+    injected as the cache-detection seam — Tier 2 contract tests
+    (POD-030, SP-6) substitute a synthetic miss to verify the contract
+    without touching the real HF cache.
+
+    Scaffold for POD-021: emits nothing until the implementation cycle
+    lands.
+    """
+    del model, is_cached, logger

--- a/src/podcast_script/backends/faster.py
+++ b/src/podcast_script/backends/faster.py
@@ -130,11 +130,18 @@ class FasterWhisperBackend:
         """Return ``True`` if a faster-whisper cache entry for ``model`` exists.
 
         Real path: lazy-imports ``huggingface_hub`` and scans the local
-        cache for any repo whose id contains ``faster-whisper-{model}``
+        cache for any repo whose id ends with ``faster-whisper-{model}``
         (matches both Systran's official conversions and community
         forks like ``mobiuslabsgmbh/faster-whisper-large-v3-turbo``).
         Override-point for unit tests — POD-030 (Tier 2, SP-6) covers
         the live HF surface.
+
+        The match anchors at the end of the repo id rather than using
+        a plain substring: ``"faster-whisper-tiny"`` is a substring of
+        ``"…/faster-whisper-tiny.en"``, and a substring matcher would
+        falsely report the bare ``tiny`` as cached when only the ``.en``
+        variant is on disk — silently suppressing the AC-US-5.1 notice
+        for an unrelated multi-GB download.
 
         On any failure (HF lib missing, scan errors, permission denied)
         returns ``False`` so the AC-US-5.1 notice fires conservatively
@@ -150,7 +157,7 @@ class FasterWhisperBackend:
         except Exception:
             return False
         target = f"faster-whisper-{model}"
-        return any(target in repo.repo_id for repo in info.repos)
+        return any(repo.repo_id.endswith(target) for repo in info.repos)
 
     def _build_model(self, model: str, device: str) -> object:
         """Construct the underlying ``faster_whisper.WhisperModel``.

--- a/src/podcast_script/backends/faster.py
+++ b/src/podcast_script/backends/faster.py
@@ -1,20 +1,26 @@
-"""C-FasterWhisper backend: ``WhisperBackend`` impl on Linux/CUDA/CPU (POD-019).
+"""C-FasterWhisper backend: ``WhisperBackend`` impl on Linux/CUDA/CPU (POD-019, POD-021).
 
 Implements :class:`~podcast_script.backends.base.WhisperBackend` (ADR-0003)
 with a lazy ``faster_whisper`` import deferred to :meth:`FasterWhisperBackend.load`
 per ADR-0011. The Pipeline (POD-008) calls ``load()`` immediately after
 CLI validation per ADR-0009 so the AC-US-5.1 first-run notice fires
-before decode (POD-021 ships the formal notice line).
+before decode.
 
-``ImportError`` from the heavy chain (CTranslate2 / tokenizers / huggingface_hub)
-and any cache / network / disk failure inside ``load()`` are wrapped in
-:class:`~podcast_script.errors.ModelError` (exit 5) per ADR-0006 and
-ADR-0011 Consequences — keeps the NFR-9 exit-code contract intact even
+POD-021 wires the AC-US-5.1 notice into ``load()``: a cheap cache check
+(:meth:`_is_cached`, lazy-importing ``huggingface_hub.scan_cache_dir``)
+runs before the heavy ``faster_whisper`` import. On a miss the locked
+``event=model_download`` line goes to stderr (ADR-0012) within the
+NFR-6 1-s budget, then ``huggingface_hub``'s own progress bar follows
+the heavy build path. ``ImportError`` from the heavy chain (CTranslate2 /
+tokenizers / huggingface_hub) and any cache / network / disk failure
+inside ``load()`` are wrapped in :class:`~podcast_script.errors.ModelError`
+(exit 5) per ADR-0006 — keeps the NFR-9 exit-code contract intact even
 when the upstream library API drifts (R-17).
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Protocol, cast
 
@@ -22,7 +28,9 @@ import numpy as np
 import numpy.typing as npt
 
 from ..errors import ModelError
-from .base import TranscribedSegment
+from .base import TranscribedSegment, emit_first_run_notice_if_missing
+
+_log = logging.getLogger(__name__)
 
 
 class _FasterSegment(Protocol):
@@ -74,12 +82,16 @@ class FasterWhisperBackend:
     def load(self, model: str, device: str) -> None:
         """Resolve and load the requested model (ADR-0009 / ADR-0011).
 
-        Subsequent calls are a no-op — the heavy build path runs once per
-        process. Wraps the universe of failure modes that ``faster_whisper``
-        + ``huggingface_hub`` surface (``ImportError`` from the lib chain,
-        ``OSError`` from disk / cache, network / HTTP errors, library API
-        drift) into :class:`ModelError` so ``cli.py``'s NFR-9 translation
-        maps them all to exit code 5 with a useful message (AC-US-5.4).
+        On a first call, runs the AC-US-5.1 cache check via
+        :meth:`_is_cached` and emits the locked ``event=model_download``
+        notice (ADR-0012) before any heavy import — so NFR-6's 1-s
+        budget holds even when the HF download is slow. Subsequent
+        calls are a no-op. Wraps the universe of failure modes that
+        ``faster_whisper`` + ``huggingface_hub`` surface (``ImportError``
+        from the lib chain, ``OSError`` from disk / cache, network /
+        HTTP errors, library API drift) into :class:`ModelError` so
+        ``cli.py``'s NFR-9 translation maps them all to exit code 5
+        with a useful message (AC-US-5.4).
 
         ``KeyboardInterrupt`` and ``SystemExit`` propagate untouched per
         ADR-0014 (Ctrl-C is the user's contract; AC-US-5.3 resume / restart
@@ -87,6 +99,11 @@ class FasterWhisperBackend:
         """
         if self._model is not None:
             return
+        emit_first_run_notice_if_missing(
+            model,
+            is_cached=self._is_cached,
+            logger=_log,
+        )
         try:
             self._model = self._build_model(model, device)
         except ImportError as e:
@@ -108,6 +125,32 @@ class FasterWhisperBackend:
                 f"Failed to load faster-whisper model '{model}': {type(e).__name__}: {e}"
             ) from e
         self._model_name = model
+
+    def _is_cached(self, model: str) -> bool:
+        """Return ``True`` if a faster-whisper cache entry for ``model`` exists.
+
+        Real path: lazy-imports ``huggingface_hub`` and scans the local
+        cache for any repo whose id contains ``faster-whisper-{model}``
+        (matches both Systran's official conversions and community
+        forks like ``mobiuslabsgmbh/faster-whisper-large-v3-turbo``).
+        Override-point for unit tests — POD-030 (Tier 2, SP-6) covers
+        the live HF surface.
+
+        On any failure (HF lib missing, scan errors, permission denied)
+        returns ``False`` so the AC-US-5.1 notice fires conservatively
+        rather than silently letting a multi-GB download surprise the
+        user.
+        """
+        try:
+            from huggingface_hub import scan_cache_dir
+        except ImportError:
+            return False
+        try:
+            info = scan_cache_dir()
+        except Exception:
+            return False
+        target = f"faster-whisper-{model}"
+        return any(target in repo.repo_id for repo in info.repos)
 
     def _build_model(self, model: str, device: str) -> object:
         """Construct the underlying ``faster_whisper.WhisperModel``.

--- a/tests/test_faster_backend.py
+++ b/tests/test_faster_backend.py
@@ -469,6 +469,62 @@ def test_default_is_cached_uses_huggingface_hub_scan(
     assert backend._is_cached("tiny") is False
 
 
+@pytest.mark.parametrize(
+    ("cached_repo_id", "requested_model", "expected"),
+    [
+        # Bare model requested, only the .en variant cached: AC-US-5.1
+        # would silently regress under a substring match. The matcher
+        # MUST anchor on the end of the repo id so this returns False.
+        ("Systran/faster-whisper-tiny.en", "tiny", False),
+        ("Systran/faster-whisper-base.en", "base", False),
+        ("Systran/faster-whisper-small.en", "small", False),
+        ("Systran/faster-whisper-medium.en", "medium", False),
+        # Same-direction matches MUST stay True — the bare model is
+        # cached, requesting it should suppress the notice (AC-US-5.2).
+        ("Systran/faster-whisper-tiny", "tiny", True),
+        ("Systran/faster-whisper-large-v3", "large-v3", True),
+        # Community fork (mobiuslabsgmbh) for large-v3-turbo MUST match;
+        # any owner/<faster-whisper-{model}> combination is valid.
+        ("mobiuslabsgmbh/faster-whisper-large-v3-turbo", "large-v3-turbo", True),
+        # Reverse direction: .en model requested, only bare cached.
+        # This correctly returns False under both matchers — the ask
+        # really is for a different repo, so the notice should fire.
+        ("Systran/faster-whisper-tiny", "tiny.en", False),
+    ],
+)
+def test_default_is_cached_anchors_match_on_end_of_repo_id(
+    monkeypatch: pytest.MonkeyPatch,
+    cached_repo_id: str,
+    requested_model: str,
+    expected: bool,
+) -> None:
+    """Regression for the AC-US-5.1 silent-suppression bug raised on PR #12:
+    a substring match (``"faster-whisper-tiny" in "…/faster-whisper-tiny.en"``)
+    falsely reports the bare ``tiny`` model as cached when only the
+    ``tiny.en`` variant is on disk, suppressing the notice while the
+    actual download for ``tiny`` runs unannounced. Anchor the match
+    on ``repo.repo_id.endswith(target)`` to disambiguate.
+    """
+
+    class _FakeRepo:
+        def __init__(self, repo_id: str) -> None:
+            self.repo_id = repo_id
+
+    class _FakeCacheInfo:
+        def __init__(self, repos: list[_FakeRepo]) -> None:
+            self.repos = repos
+
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "scan_cache_dir",
+        lambda *_a, **_k: _FakeCacheInfo([_FakeRepo(cached_repo_id)]),
+    )
+
+    assert FasterWhisperBackend()._is_cached(requested_model) is expected
+
+
 def test_default_is_cached_returns_false_when_scan_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_faster_backend.py
+++ b/tests/test_faster_backend.py
@@ -432,9 +432,7 @@ def test_load_skips_cache_check_on_repeat_call() -> None:
     backend.load(model="large-v3", device="cpu")
     backend.load(model="large-v3", device="cpu")
 
-    assert cache_calls == ["large-v3"], (
-        "second load() must short-circuit before _is_cached re-runs"
-    )
+    assert cache_calls == ["large-v3"], "second load() must short-circuit before _is_cached re-runs"
     notices = [r for r in records if getattr(r, "event", None) == "model_download"]
     assert len(notices) == 1
 
@@ -459,7 +457,7 @@ def test_default_is_cached_uses_huggingface_hub_scan(
 
     fake_cache = _FakeCacheInfo([_FakeRepo("Systran/faster-whisper-large-v3")])
 
-    import huggingface_hub  # type: ignore[import-untyped]
+    import huggingface_hub
 
     def _fake_scan(*_args: Any, **_kwargs: Any) -> _FakeCacheInfo:
         return fake_cache
@@ -480,7 +478,7 @@ def test_default_is_cached_returns_false_when_scan_fails(
     multi-GB download. False negatives are tolerable; false positives
     are not.
     """
-    import huggingface_hub  # type: ignore[import-untyped]
+    import huggingface_hub
 
     def _raising_scan(*_args: Any, **_kwargs: Any) -> Any:
         raise OSError("synthetic scan failure")

--- a/tests/test_faster_backend.py
+++ b/tests/test_faster_backend.py
@@ -1,18 +1,21 @@
-"""Tests for the C-FasterWhisper backend (POD-019).
+"""Tests for the C-FasterWhisper backend (POD-019, POD-021).
 
 Tier 1 unit tests per ADR-0017: the lazy-import boundary (ADR-0011),
-the ``ImportError`` → :class:`ModelError` wrap (ADR-0006), and the
-``transcribe()`` shape (ADR-0003 / ADR-0004) exercised against a
-mocked engine seam. The real ``faster_whisper`` is never imported in
-this suite — POD-030 (SP-6) lands the Tier 2 contract test that
+the ``ImportError`` → :class:`ModelError` wrap (ADR-0006), the
+``transcribe()`` shape (ADR-0003 / ADR-0004), and the AC-US-5.1
+first-run model-download notice (POD-021) exercised against a mocked
+cache-detection seam. The real ``faster_whisper`` is never imported
+in this suite — POD-030 (SP-6) lands the Tier 2 contract test that
 runs against the actual library.
 """
 
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 from collections.abc import Iterable, Iterator
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -290,3 +293,212 @@ def test_load_wraps_oserror_disk_failure_in_model_error() -> None:
 
     assert isinstance(exc_info.value.__cause__, OSError)
     assert "tiny" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# POD-021 — AC-US-5.1 / AC-US-5.2 first-run model-download notice integration
+# ---------------------------------------------------------------------------
+
+
+def _attach_capture(logger_name: str) -> list[logging.LogRecord]:
+    """Attach a list-recording handler to ``logger_name`` and return the list.
+
+    Direct handler attach (rather than ``caplog``) so the test does not
+    depend on ``propagate`` flags — the backend logs through its own
+    module-named child of ``podcast_script``.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = logging.getLogger(logger_name)
+    handler = _Capture()
+    handler.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    return records
+
+
+def _make_cache_aware_backend(
+    *,
+    cached: bool,
+    on_build: list[str] | None = None,
+) -> FasterWhisperBackend:
+    """Build a backend whose ``_is_cached`` is hard-wired to ``cached``.
+
+    ``_build_model`` records its invocation in ``on_build`` (if provided)
+    so callers can assert AC-US-5.1's ordering invariant: the notice
+    MUST be emitted before any heavy build path runs.
+    """
+
+    class _CacheAwareBackend(FasterWhisperBackend):
+        def _is_cached(self, model: str) -> bool:
+            return cached
+
+        def _build_model(self, model: str, device: str) -> object:
+            if on_build is not None:
+                on_build.append("build")
+            return object()
+
+    return _CacheAwareBackend()
+
+
+def test_load_emits_first_run_notice_on_cache_miss_AC_US_5_1() -> None:
+    """AC-US-5.1: when the model is not in the local cache,
+    :meth:`FasterWhisperBackend.load` MUST emit a single
+    ``level=info event=model_download model=<name> size_gb=<n>`` line
+    (locked shape per ADR-0012) so the user sees within 1 s of process
+    start that a multi-GB download is in progress (NFR-6).
+    """
+    records = _attach_capture("podcast_script.backends.faster")
+    backend = _make_cache_aware_backend(cached=False)
+
+    backend.load(model="large-v3", device="cpu")
+
+    notices = [r for r in records if getattr(r, "event", None) == "model_download"]
+    assert len(notices) == 1
+    notice = notices[0]
+    assert notice.levelno == logging.INFO
+    assert getattr(notice, "model", None) == "large-v3"
+    assert getattr(notice, "size_gb", None) == "3"
+
+
+def test_load_notice_precedes_build_model_AC_US_5_1() -> None:
+    """AC-US-5.1 / NFR-6 ordering invariant: the notice MUST be emitted
+    BEFORE :meth:`FasterWhisperBackend._build_model` is called — that
+    method is where the heavy ``faster_whisper`` import + HF download
+    triggers happen, and the 1-s budget is measured from process start.
+    Emitting after the download has begun would defeat the AC.
+    """
+    records = _attach_capture("podcast_script.backends.faster")
+    build_calls: list[str] = []
+    notices_at_build_time: list[int] = []
+
+    class _OrderingBackend(FasterWhisperBackend):
+        def _is_cached(self, model: str) -> bool:
+            return False
+
+        def _build_model(self, model: str, device: str) -> object:
+            notices_at_build_time.append(
+                sum(1 for r in records if getattr(r, "event", None) == "model_download")
+            )
+            build_calls.append("build")
+            return object()
+
+    _OrderingBackend().load(model="large-v3", device="cpu")
+
+    assert build_calls == ["build"]
+    assert notices_at_build_time == [1], (
+        "model_download notice must fire BEFORE _build_model so the "
+        "AC-US-5.1 1-s budget holds even when HF download is slow"
+    )
+
+
+def test_load_silent_on_cache_hit_AC_US_5_2() -> None:
+    """AC-US-5.2: when the requested model is already cached, no
+    ``model_download`` notice is emitted. Subsequent runs after the
+    initial download stay silent so wrappers piping the tool don't see
+    a spurious download event on every invocation.
+    """
+    records = _attach_capture("podcast_script.backends.faster")
+    backend = _make_cache_aware_backend(cached=True)
+
+    backend.load(model="large-v3", device="cpu")
+
+    notices = [r for r in records if getattr(r, "event", None) == "model_download"]
+    assert notices == []
+
+
+def test_load_skips_cache_check_on_repeat_call() -> None:
+    """ADR-0011 first-use site: a second :meth:`load` MUST short-circuit
+    before the cache check (and before any helper call). Otherwise the
+    AC-US-5.2 invariant could be violated for in-process re-use even
+    though the model was downloaded by the first call.
+    """
+    records = _attach_capture("podcast_script.backends.faster")
+    cache_calls: list[str] = []
+
+    class _CountingCacheBackend(FasterWhisperBackend):
+        def _is_cached(self, model: str) -> bool:
+            cache_calls.append(model)
+            return False
+
+        def _build_model(self, model: str, device: str) -> object:
+            return object()
+
+    backend = _CountingCacheBackend()
+    backend.load(model="large-v3", device="cpu")
+    backend.load(model="large-v3", device="cpu")
+
+    assert cache_calls == ["large-v3"], (
+        "second load() must short-circuit before _is_cached re-runs"
+    )
+    notices = [r for r in records if getattr(r, "event", None) == "model_download"]
+    assert len(notices) == 1
+
+
+def test_default_is_cached_uses_huggingface_hub_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real ``_is_cached`` path: stub ``huggingface_hub.scan_cache_dir``
+    to return a synthetic cache containing ``Systran/faster-whisper-large-v3``
+    and assert :meth:`_is_cached` returns ``True`` for ``large-v3`` and
+    ``False`` for ``tiny`` (not in the synthetic cache). The real lib is
+    consulted only here — POD-030 (Tier 2) covers the live HF surface.
+    """
+
+    class _FakeRepo:
+        def __init__(self, repo_id: str) -> None:
+            self.repo_id = repo_id
+
+    class _FakeCacheInfo:
+        def __init__(self, repos: list[_FakeRepo]) -> None:
+            self.repos = repos
+
+    fake_cache = _FakeCacheInfo([_FakeRepo("Systran/faster-whisper-large-v3")])
+
+    import huggingface_hub  # type: ignore[import-untyped]
+
+    def _fake_scan(*_args: Any, **_kwargs: Any) -> _FakeCacheInfo:
+        return fake_cache
+
+    monkeypatch.setattr(huggingface_hub, "scan_cache_dir", _fake_scan)
+
+    backend = FasterWhisperBackend()
+    assert backend._is_cached("large-v3") is True
+    assert backend._is_cached("tiny") is False
+
+
+def test_default_is_cached_returns_false_when_scan_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``huggingface_hub.scan_cache_dir`` raises (corrupt cache,
+    permission denied, etc.), ``_is_cached`` MUST return ``False`` — i.e.
+    err on the side of emitting the notice, never silently swallow a
+    multi-GB download. False negatives are tolerable; false positives
+    are not.
+    """
+    import huggingface_hub  # type: ignore[import-untyped]
+
+    def _raising_scan(*_args: Any, **_kwargs: Any) -> Any:
+        raise OSError("synthetic scan failure")
+
+    monkeypatch.setattr(huggingface_hub, "scan_cache_dir", _raising_scan)
+
+    assert FasterWhisperBackend()._is_cached("large-v3") is False
+
+
+def test_module_does_not_eagerly_import_huggingface_hub() -> None:
+    """ADR-0011: importing :mod:`podcast_script.backends.faster` at CLI
+    startup MUST NOT trigger a ``huggingface_hub`` import — the cache
+    check is lazy too. Companion to the ``faster_whisper`` lazy-boundary
+    test at the top of this file.
+    """
+    sys.modules.pop("podcast_script.backends.faster", None)
+    sys.modules.pop("huggingface_hub", None)
+
+    importlib.import_module("podcast_script.backends.faster")
+
+    assert "huggingface_hub" not in sys.modules

--- a/tests/test_first_run_notice.py
+++ b/tests/test_first_run_notice.py
@@ -1,0 +1,139 @@
+"""Tests for the first-run model-download notice helper (POD-021).
+
+Tier 1 unit tests per ADR-0017 covering ``emit_first_run_notice_if_missing``
+in :mod:`podcast_script.backends.base` — the shared seam each
+``WhisperBackend`` impl calls from its ``load()`` to satisfy AC-US-5.1
+(notice on cache miss within NFR-6's 1-s budget) and AC-US-5.2
+(silence on cache hit). The locked event shape is owned by ADR-0012:
+``level=info event=model_download model=<name> size_gb=<n>``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from podcast_script.backends.base import (
+    MODEL_SIZES_GB,
+    emit_first_run_notice_if_missing,
+)
+
+
+def _capture_records(logger_name: str) -> tuple[logging.Logger, list[logging.LogRecord]]:
+    """Attach a list-recording handler to ``logger_name`` and return both.
+
+    Direct handler attach (rather than ``caplog``) so the test does not
+    depend on ``propagate`` flags set by :func:`podcast_script.logging_setup.configure`
+    — the helper-level tests exercise the bare logger surface.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = logging.getLogger(logger_name)
+    handler = _Capture()
+    handler.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    return logger, records
+
+
+def test_emits_locked_shape_on_cache_miss() -> None:
+    """AC-US-5.1 + ADR-0012: on a cache miss the helper MUST emit exactly
+    one ``level=info event=model_download model=<name> size_gb=<n>``
+    record. Shape locked — adding/removing keys is a SemVer-major event
+    per SRS §16.1, so this test is the contract test for the helper.
+    """
+    logger, records = _capture_records("podcast_script.test_first_run.miss")
+
+    emit_first_run_notice_if_missing(
+        "large-v3",
+        is_cached=lambda _model: False,
+        logger=logger,
+    )
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.levelno == logging.INFO
+    assert getattr(rec, "event", None) == "model_download"
+    assert getattr(rec, "model", None) == "large-v3"
+    assert getattr(rec, "size_gb", None) == "3"
+
+
+def test_silent_on_cache_hit_AC_US_5_2() -> None:
+    """AC-US-5.2: when the model is already cached, the helper MUST NOT
+    emit anything. Subsequent runs after the first download stay silent
+    so wrappers piping the tool don't see a spurious ``model_download``
+    event on every re-run.
+    """
+    logger, records = _capture_records("podcast_script.test_first_run.hit")
+
+    emit_first_run_notice_if_missing(
+        "large-v3",
+        is_cached=lambda _model: True,
+        logger=logger,
+    )
+
+    assert records == []
+
+
+def test_unknown_model_falls_back_to_one_gb() -> None:
+    """When the user passes a model name we don't recognize (e.g. a
+    custom HF repo) we still want the user warned that a download may be
+    coming. The helper falls back to a conservative 1 GB estimate — they
+    will see ``huggingface_hub``'s real progress bar shortly after.
+    """
+    logger, records = _capture_records("podcast_script.test_first_run.unknown")
+
+    emit_first_run_notice_if_missing(
+        "totally-custom-model",
+        is_cached=lambda _model: False,
+        logger=logger,
+    )
+
+    assert len(records) == 1
+    assert getattr(records[0], "size_gb", None) == "1"
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("tiny", "0.075"),
+        ("base", "0.14"),
+        ("small", "0.46"),
+        ("medium", "1.5"),
+        ("large-v3", "3"),
+        ("large-v3-turbo", "1.6"),
+    ],
+)
+def test_size_formatting_matches_table(model: str, expected: str) -> None:
+    """The on-the-wire ``size_gb`` token MUST come from
+    :data:`MODEL_SIZES_GB` formatted with ``:g`` — round numbers render
+    bare (``3``), fractional ones keep their decimals (``0.075``,
+    ``1.5``). Keeps the line short and human-readable while staying
+    deterministic across versions.
+    """
+    logger, records = _capture_records(f"podcast_script.test_first_run.size.{model}")
+
+    emit_first_run_notice_if_missing(
+        model,
+        is_cached=lambda _model: False,
+        logger=logger,
+    )
+
+    assert getattr(records[0], "size_gb", None) == expected
+
+
+def test_known_model_table_covers_v1_supported_set() -> None:
+    """The v1 model set the README documents (tiny / base / small /
+    medium / large-v3 / large-v3-turbo) MUST all be in
+    :data:`MODEL_SIZES_GB` so users running any of them see an accurate
+    size in the AC-US-5.1 notice. Adding a model post-v1 is a minor
+    update; removing one is breaking.
+    """
+    required = {"tiny", "base", "small", "medium", "large-v3", "large-v3-turbo"}
+
+    assert required <= MODEL_SIZES_GB.keys()


### PR DESCRIPTION
## Summary
- Closes **POD-021** under **US-5** (Must, 5 pts) in sprint **SP-3**.
- Adds the AC-US-5.1 first-run download notice: on a cache miss `FasterWhisperBackend.load()` emits the locked ADR-0012 shape `level=info event=model_download model=<name> size_gb=<n>` **before** any heavy import / network call, so the user sees within NFR-6's 1-s budget that a multi-GB download is in progress.
- Centralises the emit-once logic in `backends/base.py::emit_first_run_notice_if_missing(model, *, is_cached, logger)` so the upcoming `MlxWhisperBackend` (POD-020, SP-4) plugs in without duplication.

## Acceptance criteria satisfied
- [x] **AC-US-5.1** — covered by `tests/test_first_run_notice.py::test_emits_locked_shape_on_cache_miss` (helper) + `tests/test_faster_backend.py::test_load_emits_first_run_notice_on_cache_miss_AC_US_5_1` + `…::test_load_notice_precedes_build_model_AC_US_5_1` (backend ordering invariant — notice emitted before `_build_model`).
- [x] **AC-US-5.2** — covered by `tests/test_first_run_notice.py::test_silent_on_cache_hit_AC_US_5_2` + `tests/test_faster_backend.py::test_load_silent_on_cache_hit_AC_US_5_2` + `…::test_load_skips_cache_check_on_repeat_call` (in-process re-use also stays silent).

## Implementation notes
- `MODEL_SIZES_GB` populated for the v1 set (tiny / base / small / medium / large* / large-v3-turbo); unknown models fall back to a conservative 1 GB warning rather than silent.
- `size_gb` rendered via `f"{size:g}"` so round numbers ship bare (`size_gb=3`) and fractional sizes keep their decimals (`size_gb=0.075`).
- `FasterWhisperBackend._is_cached(model)` is the override-point. Real path lazy-imports `huggingface_hub.scan_cache_dir` (preserves the ADR-0011 boundary — verified by `test_module_does_not_eagerly_import_huggingface_hub`) and substring-matches `"faster-whisper-{model}"` against cached repo ids — covers Systran's official conversions and forks like `mobiuslabsgmbh/faster-whisper-large-v3-turbo`.
- On any cache-scan failure (HF lib missing, OS error, permission denied) `_is_cached` returns `False`. False negatives are tolerable (one extra log line); false positives are not (silent multi-GB download).
- POD-019's existing `ModelError` wrap (AC-US-5.4) is unchanged.

## Risks touched
- **R-14** (huggingface_hub API evolution) — POD-021 only depends on `scan_cache_dir`; broad failure-mode wrap in `_is_cached` keeps behaviour graceful if the API drifts. The 1-s contract test (Tier 2, POD-030, SP-6) will pin the contract more tightly.
- **R-17** (faster-whisper API drift) — unaffected; `_is_cached` reads HF cache directly, not via `faster_whisper`.

## Documentation
- README (POD-036, SP-7) and CHANGELOG (POD-038, SP-8) are not yet in the repo per the SP plan — no edits this PR.
- ADR-0012 already locks the `event=model_download` shape — no ADR change.
- Module + method docstrings in `backends/base.py` and `backends/faster.py` updated to describe POD-021 wiring.

## Test plan
- [x] Helper-level Tier 1 unit tests (`tests/test_first_run_notice.py`, 10 tests).
- [x] Backend integration Tier 1 unit tests (`tests/test_faster_backend.py` POD-021 section, 7 new tests).
- [x] Full pytest suite: **139 passed** (was 122 on `main`).
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy --strict` clean on `src/podcast_script` + `tests`.
- [ ] CI matrix (Ubuntu + macOS-14) — pending on push.
- [ ] Reviewer to sanity-check the `faster-whisper-{model}` substring matcher against any non-standard repo ids they have cached locally.

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target.
- [x] Tests green locally (139/139).
- [x] Lint + format + type-check clean.
- [ ] CI matrix green (post-push).
- [ ] Maintainer self-review per Q7 (smoke deferred — no real backend exercise needed for AC-US-5.1; HF cache-miss path covered by the synthetic-seam tests).
- [ ] Docs (README/CHANGELOG): owned by POD-036/POD-038, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)