### PR TITLE
feat(POD-020): C-MlxWhisper backend with lazy import + ModelError wrap (US-5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,14 @@ python_version = "3.12"
 strict = true
 files = ["src", "tests"]
 
+# mlx-whisper is darwin/arm64-only (PEP 508 marker in [project]) and
+# ships no type stubs. Waiving missing-imports and missing-stubs here
+# so strict mode stays clean on Ubuntu CI (where mlx_whisper is not
+# installed) and on macOS CI (where it is installed but untyped).
+[[tool.mypy.overrides]]
+module = ["mlx_whisper", "mlx_whisper.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["-ra", "--strict-markers", "--strict-config"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "faster-whisper>=1.0",
     "huggingface_hub>=0.24",
     "inaspeechsegmenter==0.7.6",
+    "mlx-whisper>=0.4 ; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "numpy>=2.0",
     "rich>=13.7",
     "typer>=0.25.0",

--- a/src/podcast_script/backends/mlx.py
+++ b/src/podcast_script/backends/mlx.py
@@ -20,6 +20,12 @@ when the upstream library API drifts (R-17).
 
 from __future__ import annotations
 
+import logging
+
+from ..errors import ModelError
+
+_log = logging.getLogger(__name__)
+
 
 class MlxWhisperBackend:
     """``mlx-whisper``-backed implementation of
@@ -27,8 +33,57 @@ class MlxWhisperBackend:
 
     Construction is cheap — the heavy ``mlx_whisper`` import does not
     happen until :meth:`load` is called (ADR-0011 first-use site). The
-    later TDD cycles in POD-020 add :meth:`load` and :meth:`transcribe`
-    on top of this skeleton.
+    ``transcribe`` method (POD-020 follow-up cycle) iterates the
+    underlying ``mlx_whisper.transcribe`` segments and re-shapes them as
+    :class:`~podcast_script.backends.base.TranscribedSegment` triples
+    per ADR-0003.
     """
 
     name = "mlx-whisper"
+
+    def __init__(self) -> None:
+        self._model: object | None = None
+        self._model_name: str | None = None
+
+    def load(self, model: str, device: str) -> None:
+        """Resolve and load the requested model (ADR-0009 / ADR-0011).
+
+        Subsequent calls are a no-op (cached model). Wraps
+        ``ImportError`` from the heavy ``mlx_whisper`` / ``mlx`` /
+        ``huggingface_hub`` chain into :class:`ModelError` so
+        ``cli.py``'s NFR-9 translation maps it to exit code 5 with a
+        useful message instead of the unexpected-internal fallback.
+
+        ``device`` is accepted for Protocol symmetry with
+        :class:`~podcast_script.backends.faster.FasterWhisperBackend`
+        but unused: ``mlx_whisper`` always runs on the unified-memory
+        Apple Silicon GPU.
+        """
+        if self._model is not None:
+            return
+        try:
+            self._model = self._build_model(model, device)
+        except ImportError as e:
+            raise ModelError(
+                f"mlx-whisper (or one of its dependencies: mlx, "
+                f"huggingface_hub) is not installed — run `uv sync` on "
+                f"an Apple Silicon machine. Cannot load model '{model}'."
+            ) from e
+        self._model_name = model
+
+    def _build_model(self, model: str, device: str) -> object:
+        """Construct (download + load) the underlying ``mlx_whisper`` model.
+
+        Override-point for unit tests (subclass and replace this method
+        to return a stub model without touching the heavy chain).
+        Production code path triggers the lazy ``mlx_whisper`` import
+        here and delegates HF cache lookup + first-run download to
+        ``mlx_whisper.load_models.load_model``.
+        """
+        # ``mlx_whisper`` is darwin-arm64-only via the PEP 508 marker
+        # in ``pyproject.toml``; ``[[tool.mypy.overrides]]`` waives
+        # missing-imports and missing-stubs uniformly across CI
+        # platforms (Ubuntu: not installed; macOS: installed, untyped).
+        from mlx_whisper.load_models import load_model
+
+        return load_model(model)

--- a/src/podcast_script/backends/mlx.py
+++ b/src/podcast_script/backends/mlx.py
@@ -91,11 +91,20 @@ class MlxWhisperBackend:
     def load(self, model: str, device: str) -> None:
         """Resolve and load the requested model (ADR-0009 / ADR-0011).
 
-        Subsequent calls are a no-op (cached model). Wraps
-        ``ImportError`` from the heavy ``mlx_whisper`` / ``mlx`` /
-        ``huggingface_hub`` chain into :class:`ModelError` so
-        ``cli.py``'s NFR-9 translation maps it to exit code 5 with a
-        useful message instead of the unexpected-internal fallback.
+        On a first call, runs the AC-US-5.1 cache check via
+        :meth:`_is_cached` and emits the locked ``event=model_download``
+        notice (ADR-0012) before any heavy import — so NFR-6's 1-s
+        budget holds even when the HF download is slow. Subsequent
+        calls are a no-op. Wraps the universe of failure modes that
+        ``mlx_whisper`` + ``huggingface_hub`` surface (``ImportError``
+        from the lib chain, ``OSError`` from disk / cache, network /
+        HTTP errors, library API drift) into :class:`ModelError` so
+        ``cli.py``'s NFR-9 translation maps them all to exit code 5
+        with a useful message (AC-US-5.4).
+
+        ``KeyboardInterrupt`` and ``SystemExit`` propagate untouched per
+        ADR-0014 (Ctrl-C is the user's contract; AC-US-5.3 resume /
+        restart is on the user, not us).
 
         ``device`` is accepted for Protocol symmetry with
         :class:`~podcast_script.backends.faster.FasterWhisperBackend`
@@ -116,6 +125,18 @@ class MlxWhisperBackend:
                 f"mlx-whisper (or one of its dependencies: mlx, "
                 f"huggingface_hub) is not installed — run `uv sync` on "
                 f"an Apple Silicon machine. Cannot load model '{model}'."
+            ) from e
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            # huggingface_hub spans a wide exception vocabulary
+            # (httpx.ConnectError, HfHubHTTPError, OSError, ...). Any
+            # non-ImportError failure during model resolution is a
+            # ModelError (exit 5) per AC-US-5.4. R-17 (mlx-whisper API
+            # drift) is also covered by this broad wrap — surfacing the
+            # original via __cause__ keeps the trace debuggable.
+            raise ModelError(
+                f"Failed to load mlx-whisper model '{model}': {type(e).__name__}: {e}"
             ) from e
         self._model_name = model
 

--- a/src/podcast_script/backends/mlx.py
+++ b/src/podcast_script/backends/mlx.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 
 from ..errors import ModelError
+from .base import emit_first_run_notice_if_missing
 
 _log = logging.getLogger(__name__)
 
@@ -61,6 +62,11 @@ class MlxWhisperBackend:
         """
         if self._model is not None:
             return
+        emit_first_run_notice_if_missing(
+            model,
+            is_cached=self._is_cached,
+            logger=_log,
+        )
         try:
             self._model = self._build_model(model, device)
         except ImportError as e:
@@ -70,6 +76,37 @@ class MlxWhisperBackend:
                 f"an Apple Silicon machine. Cannot load model '{model}'."
             ) from e
         self._model_name = model
+
+    def _is_cached(self, model: str) -> bool:
+        """Return ``True`` if an mlx-whisper cache entry for ``model`` exists.
+
+        Real path: lazy-imports ``huggingface_hub`` and scans the local
+        cache for any repo whose id ends with ``/whisper-{model}``. The
+        leading slash is load-bearing — it disambiguates ``mlx-community``
+        repos (``mlx-community/whisper-tiny``) from the faster-whisper
+        siblings (``Systran/faster-whisper-tiny``) that share the same
+        ``~/.cache/huggingface`` directory. Without the slash anchor,
+        a faster cache entry would falsely report the mlx model as
+        cached and silently suppress the AC-US-5.1 notice.
+
+        Override-point for unit tests — POD-030 (Tier 2, SP-6) covers
+        the live HF surface on macOS CI.
+
+        On any failure (HF lib missing, scan errors, permission denied)
+        returns ``False`` so the AC-US-5.1 notice fires conservatively
+        rather than silently letting a multi-GB download surprise the
+        user.
+        """
+        try:
+            from huggingface_hub import scan_cache_dir
+        except ImportError:
+            return False
+        try:
+            info = scan_cache_dir()
+        except Exception:
+            return False
+        target = f"/whisper-{model}"
+        return any(repo.repo_id.endswith(target) for repo in info.repos)
 
     def _build_model(self, model: str, device: str) -> object:
         """Construct (download + load) the underlying ``mlx_whisper`` model.

--- a/src/podcast_script/backends/mlx.py
+++ b/src/podcast_script/backends/mlx.py
@@ -21,11 +21,53 @@ when the upstream library API drifts (R-17).
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any, Protocol
+
+import numpy as np
+import numpy.typing as npt
 
 from ..errors import ModelError
-from .base import emit_first_run_notice_if_missing
+from .base import TranscribedSegment, emit_first_run_notice_if_missing
 
 _log = logging.getLogger(__name__)
+
+
+class _MlxSegment(Protocol):
+    """Structural contract for one mlx-whisper segment.
+
+    ``mlx_whisper.transcribe`` returns dicts in its ``"segments"`` list;
+    ``_run_inference`` adapts them into objects matching this Protocol
+    so :meth:`MlxWhisperBackend.transcribe` is symmetric with the
+    faster-whisper sibling. Declared at module top (not under
+    ``TYPE_CHECKING``) so unit tests can stub the surface with their
+    own duck-types — structural compatibility is the contract.
+    """
+
+    start: float
+    end: float
+    text: str
+
+
+class _MlxSegmentTriple:
+    """Concrete :class:`_MlxSegment` used by the production path.
+
+    The real-library branch of :meth:`MlxWhisperBackend._run_inference`
+    wraps each ``mlx_whisper`` segment dict in one of these — turning
+    ``seg["start"]`` into ``triple.start`` so :meth:`.transcribe` can
+    consume any :class:`_MlxSegment` (real triples or test fakes) by
+    attribute access. A plain class (not :class:`NamedTuple` /
+    ``frozen=True`` dataclass) is used so the read-only-vs-settable
+    variance check in :class:`_MlxSegment` stays satisfied without
+    declaring every attribute as a ``@property``.
+    """
+
+    __slots__ = ("end", "start", "text")
+
+    def __init__(self, start: float, end: float, text: str) -> None:
+        self.start = start
+        self.end = end
+        self.text = text
 
 
 class MlxWhisperBackend:
@@ -124,3 +166,69 @@ class MlxWhisperBackend:
         from mlx_whisper.load_models import load_model
 
         return load_model(model)
+
+    def transcribe(
+        self,
+        pcm: npt.NDArray[np.float32],
+        lang: str,
+        sample_rate: int = 16000,
+    ) -> Iterator[TranscribedSegment]:
+        """Transcribe one mono float32 PCM slice (ADR-0003 / ADR-0004).
+
+        Yields :class:`TranscribedSegment` triples lazily — the
+        underlying ``_run_inference`` is iterable, and we re-shape each
+        item without buffering. The Pipeline (POD-008) feeds one speech
+        segment at a time per ADR-0004 streaming contract, and the
+        per-segment progress tick (POD-013, ADR-0010) relies on the lazy
+        yield to advance smoothly.
+        """
+        if self._model is None:
+            raise ModelError(
+                "MlxWhisperBackend.transcribe() called before load(); "
+                "the orchestrator must call load() first per ADR-0009."
+            )
+        raw = self._run_inference(self._model, pcm, lang)
+        for seg in raw:
+            yield TranscribedSegment(
+                start=float(seg.start),
+                end=float(seg.end),
+                text=str(seg.text),
+            )
+
+    def _run_inference(
+        self,
+        model: object,
+        pcm: npt.NDArray[np.float32],
+        lang: str,
+    ) -> Iterable[_MlxSegment]:
+        """Run ``mlx_whisper.transcribe`` and yield duck-typed segments.
+
+        Override-point for unit tests. ``mlx_whisper.transcribe`` is a
+        function (not a method on the loaded model); it returns a dict
+        with a ``"segments"`` list of dicts. We adapt those dicts into
+        :class:`_MlxSegmentTriple` instances so :meth:`transcribe` can
+        consume the same attribute interface as the faster-whisper
+        sibling.
+
+        ``model`` is unused here — ``mlx_whisper.transcribe`` re-loads
+        from ``path_or_hf_repo`` each call (it has its own module-level
+        cache); we pass ``self._model_name`` for that purpose. The
+        argument is kept for seam symmetry with the faster sibling.
+        """
+        import mlx_whisper
+
+        if self._model_name is None:
+            raise ModelError(
+                "MlxWhisperBackend internal state is invalid: _model_name unset after load()."
+            )
+        result: Mapping[str, Any] = mlx_whisper.transcribe(
+            pcm,
+            path_or_hf_repo=self._model_name,
+            language=lang,
+        )
+        for seg in result.get("segments", []):
+            yield _MlxSegmentTriple(
+                start=float(seg["start"]),
+                end=float(seg["end"]),
+                text=str(seg["text"]),
+            )

--- a/src/podcast_script/backends/mlx.py
+++ b/src/podcast_script/backends/mlx.py
@@ -1,0 +1,34 @@
+"""C-MlxWhisper backend: ``WhisperBackend`` impl on Apple Silicon (POD-020).
+
+Mirror of :mod:`podcast_script.backends.faster` for the macOS arm64
+platform. Implements :class:`~podcast_script.backends.base.WhisperBackend`
+(ADR-0003) with a lazy ``mlx_whisper`` import deferred to
+:meth:`MlxWhisperBackend.load` per ADR-0011 — the heavy
+``mlx_whisper`` / ``mlx`` / ``numba`` chain stays out of CLI startup so
+``select_backend`` (POD-017, SP-4) can probe both backends without
+paying either one's cold-import cost.
+
+The Pipeline (POD-008) calls ``load()`` immediately after CLI validation
+per ADR-0009, which is also where the AC-US-5.1 first-run notice fires
+through the shared :func:`~.base.emit_first_run_notice_if_missing`
+helper. ``ImportError`` from the heavy chain (``mlx``, ``mlx_whisper``,
+``huggingface_hub``) and any cache / network / disk failure inside
+``load()`` are wrapped in :class:`~podcast_script.errors.ModelError`
+(exit 5) per ADR-0006, keeping the NFR-9 exit-code contract intact even
+when the upstream library API drifts (R-17).
+"""
+
+from __future__ import annotations
+
+
+class MlxWhisperBackend:
+    """``mlx-whisper``-backed implementation of
+    :class:`~podcast_script.backends.base.WhisperBackend` for Apple Silicon.
+
+    Construction is cheap — the heavy ``mlx_whisper`` import does not
+    happen until :meth:`load` is called (ADR-0011 first-use site). The
+    later TDD cycles in POD-020 add :meth:`load` and :meth:`transcribe`
+    on top of this skeleton.
+    """
+
+    name = "mlx-whisper"

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -1,0 +1,50 @@
+"""Tests for the C-MlxWhisper backend (POD-020).
+
+Tier 1 unit tests per ADR-0017: the lazy-import boundary (ADR-0011),
+the ``ImportError`` → :class:`ModelError` wrap (ADR-0006), the
+``transcribe()`` shape (ADR-0003 / ADR-0004), and the AC-US-5.1 /
+AC-US-5.2 first-run model-download notice exercised against a mocked
+cache-detection seam. Mirrors :mod:`tests.test_faster_backend` for the
+sibling ``MlxWhisperBackend`` — the real ``mlx_whisper`` is never
+imported in this suite (POD-030 lands the Tier 2 contract test against
+the actual library on the macOS CI lane).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+# ---------------------------------------------------------------------------
+# ADR-0011 — module-level lazy-import boundary
+# ---------------------------------------------------------------------------
+
+
+def test_module_does_not_eagerly_import_mlx_whisper() -> None:
+    """ADR-0011: ``backends/mlx.py`` MUST NOT import ``mlx_whisper`` at
+    module top — the heavy MLX / torch / numba chain is deferred to
+    first-use inside :meth:`MlxWhisperBackend.load`. Importing the module
+    (e.g. for ``select_backend`` resolution at CLI startup) must not
+    trigger the cold-import cost on Apple Silicon.
+    """
+    sys.modules.pop("podcast_script.backends.mlx", None)
+    sys.modules.pop("mlx_whisper", None)
+
+    importlib.import_module("podcast_script.backends.mlx")
+
+    assert "mlx_whisper" not in sys.modules
+
+
+def test_constructor_does_not_import_mlx_whisper() -> None:
+    """ADR-0011: instantiating the backend MUST be cheap — the heavy
+    library is loaded only when :meth:`load` is called. Companion to the
+    module-level test: this guards the *class-construction* boundary.
+    """
+    sys.modules.pop("mlx_whisper", None)
+
+    from podcast_script.backends.mlx import MlxWhisperBackend
+
+    backend = MlxWhisperBackend()
+
+    assert backend.name == "mlx-whisper"
+    assert "mlx_whisper" not in sys.modules

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -73,12 +73,14 @@ def test_constructor_does_not_import_mlx_whisper() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_backend_with_build_error(error: Exception) -> MlxWhisperBackend:
+def _make_backend_with_build_error(error: BaseException) -> MlxWhisperBackend:
     """Build a backend whose ``_build_model`` raises ``error`` on load.
 
-    Helper kept here (rather than in conftest) because no other test file
-    needs it; POD-030 (Tier 2 contract) tests will run against the real
-    backend, not via this seam.
+    Accepts :class:`BaseException` (not just :class:`Exception`) so the
+    ADR-0014 propagation test can drive ``KeyboardInterrupt`` through
+    the same seam. Helper kept here (rather than in conftest) because
+    no other test file needs it; POD-030 (Tier 2 contract) tests will
+    run against the real backend, not via this seam.
     """
 
     class _ErrorBackend(MlxWhisperBackend):

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -15,12 +15,22 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+from collections.abc import Iterable, Iterator
 from typing import Any
 
+import numpy as np
+import numpy.typing as npt
 import pytest
 
+from podcast_script.backends.base import TranscribedSegment
 from podcast_script.backends.mlx import MlxWhisperBackend
 from podcast_script.errors import ModelError
+
+SAMPLE_RATE = 16_000
+
+
+def _silence_pcm(duration_s: float) -> npt.NDArray[np.float32]:
+    return np.zeros(int(duration_s * SAMPLE_RATE), dtype=np.float32)
 
 # ---------------------------------------------------------------------------
 # ADR-0011 — module-level lazy-import boundary
@@ -114,6 +124,124 @@ def test_load_caches_model_across_calls() -> None:
     backend.load(model="tiny", device="cpu")
 
     assert build_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# ADR-0003 / ADR-0004 — transcribe() shape (Iterable[TranscribedSegment])
+# ---------------------------------------------------------------------------
+
+
+class _FakeMlxSegment:
+    """Stand-in for one ``mlx_whisper`` segment object.
+
+    The real lib emits dicts (``{"start", "end", "text", ...}``) inside
+    the ``"segments"`` list of the ``transcribe`` result. The backend's
+    ``_run_inference`` seam adapts those dicts into objects matching
+    this duck type (``.start``, ``.end``, ``.text`` attributes) so
+    ``transcribe()`` is symmetric with the faster-whisper sibling — the
+    unit test exercises ``transcribe()`` directly through this stub.
+    """
+
+    def __init__(self, start: float, end: float, text: str) -> None:
+        self.start = start
+        self.end = end
+        self.text = text
+
+
+def _make_backend_with_canned_segments(
+    segments: list[_FakeMlxSegment],
+) -> MlxWhisperBackend:
+    """Build a backend whose ``_run_inference`` returns ``segments``.
+
+    The seam is the ``_run_inference`` hook so unit tests don't depend
+    on ``mlx_whisper.transcribe``'s API shape (which returns a dict and
+    re-loads from ``path_or_hf_repo``).
+    """
+
+    class _CannedBackend(MlxWhisperBackend):
+        def _build_model(self, model: str, device: str) -> object:
+            return object()
+
+        def _run_inference(
+            self,
+            model: object,
+            pcm: npt.NDArray[np.float32],
+            lang: str,
+        ) -> Iterable[_FakeMlxSegment]:
+            return iter(segments)
+
+    backend = _CannedBackend()
+    backend.load(model="tiny", device="cpu")
+    return backend
+
+
+def test_transcribe_yields_typed_segments() -> None:
+    """ADR-0003: ``transcribe`` MUST yield :class:`TranscribedSegment`
+    triples (``start``, ``end``, ``text``) — not the raw library dict.
+    The Pipeline (POD-008) consumes the abstraction, never the lib.
+    """
+    canned = [
+        _FakeMlxSegment(start=0.0, end=2.5, text="hola"),
+        _FakeMlxSegment(start=2.5, end=4.0, text="qué tal"),
+    ]
+    backend = _make_backend_with_canned_segments(canned)
+
+    out = list(backend.transcribe(_silence_pcm(4.0), lang="es"))
+
+    assert out == [
+        TranscribedSegment(start=0.0, end=2.5, text="hola"),
+        TranscribedSegment(start=2.5, end=4.0, text="qué tal"),
+    ]
+
+
+def test_transcribe_streams_lazily_per_ADR_0004() -> None:
+    """ADR-0004: ``transcribe`` is a streaming contract — segments are
+    yielded one-by-one, not buffered. The Pipeline relies on this for
+    per-segment progress ticks (POD-013, ADR-0010). Stub the underlying
+    iterator so we can assert items arrive incrementally.
+    """
+    yielded_count = 0
+
+    def _generator() -> Iterator[_FakeMlxSegment]:
+        nonlocal yielded_count
+        for seg in [
+            _FakeMlxSegment(0.0, 1.0, "uno"),
+            _FakeMlxSegment(1.0, 2.0, "dos"),
+        ]:
+            yielded_count += 1
+            yield seg
+
+    class _StreamingBackend(MlxWhisperBackend):
+        def _build_model(self, model: str, device: str) -> object:
+            return object()
+
+        def _run_inference(
+            self,
+            model: object,
+            pcm: npt.NDArray[np.float32],
+            lang: str,
+        ) -> Iterable[_FakeMlxSegment]:
+            return _generator()
+
+    backend = _StreamingBackend()
+    backend.load(model="tiny", device="cpu")
+    stream = backend.transcribe(_silence_pcm(2.0), lang="es")
+
+    first = next(iter(stream))
+    assert first.text == "uno"
+    assert yielded_count == 1
+
+
+def test_transcribe_before_load_raises_model_error() -> None:
+    """Calling :meth:`transcribe` before :meth:`load` is a programming
+    error in the orchestrator (the Pipeline always calls ``load()``
+    first per ADR-0009). Surface as :class:`ModelError` rather than a
+    ``None``-attribute traceback so the cli's NFR-9 mapping holds.
+    """
+    backend = MlxWhisperBackend()
+
+    with pytest.raises(ModelError, match="load"):
+        list(backend.transcribe(_silence_pcm(1.0), lang="es"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -15,6 +15,11 @@ from __future__ import annotations
 import importlib
 import sys
 
+import pytest
+
+from podcast_script.backends.mlx import MlxWhisperBackend
+from podcast_script.errors import ModelError
+
 # ---------------------------------------------------------------------------
 # ADR-0011 — module-level lazy-import boundary
 # ---------------------------------------------------------------------------
@@ -48,3 +53,62 @@ def test_constructor_does_not_import_mlx_whisper() -> None:
 
     assert backend.name == "mlx-whisper"
     assert "mlx_whisper" not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# ADR-0006 / ADR-0011 Consequences — ImportError wrap inside load()
+# ---------------------------------------------------------------------------
+
+
+def _make_backend_with_build_error(error: Exception) -> MlxWhisperBackend:
+    """Build a backend whose ``_build_model`` raises ``error`` on load.
+
+    Helper kept here (rather than in conftest) because no other test file
+    needs it; POD-030 (Tier 2 contract) tests will run against the real
+    backend, not via this seam.
+    """
+
+    class _ErrorBackend(MlxWhisperBackend):
+        def _build_model(self, model: str, device: str) -> object:
+            raise error
+
+    return _ErrorBackend()
+
+
+def test_load_wraps_import_error_in_model_error() -> None:
+    """ADR-0011 Consequences: an ``ImportError`` from the heavy chain
+    (``mlx``, ``mlx_whisper``, ``huggingface_hub``) MUST surface as
+    :class:`ModelError` (exit 5) so ``cli.py``'s NFR-9 mapping translates
+    it to the published exit-code contract instead of the unexpected
+    fallback (exit 1).
+    """
+    backend = _make_backend_with_build_error(
+        ImportError("No module named 'mlx_whisper'"),
+    )
+
+    with pytest.raises(ModelError) as exc_info:
+        backend.load(model="tiny", device="cpu")
+
+    assert isinstance(exc_info.value.__cause__, ImportError)
+    assert "mlx-whisper" in str(exc_info.value)
+
+
+def test_load_caches_model_across_calls() -> None:
+    """ADR-0011 first-use site: a second :meth:`load` call MUST NOT
+    re-invoke the heavy build path. The Pipeline calls ``load()`` once
+    per run today (ADR-0009), but in-process re-use (e.g. a future batch
+    mode) must not pay the cost twice.
+    """
+    build_calls = 0
+
+    class _CountingBackend(MlxWhisperBackend):
+        def _build_model(self, model: str, device: str) -> object:
+            nonlocal build_calls
+            build_calls += 1
+            return object()
+
+    backend = _CountingBackend()
+    backend.load(model="tiny", device="cpu")
+    backend.load(model="tiny", device="cpu")
+
+    assert build_calls == 1

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -13,7 +13,9 @@ the actual library on the macOS CI lane).
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
+from typing import Any
 
 import pytest
 
@@ -112,3 +114,267 @@ def test_load_caches_model_across_calls() -> None:
     backend.load(model="tiny", device="cpu")
 
     assert build_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-US-5.1 / AC-US-5.2 — first-run model-download notice integration
+# ---------------------------------------------------------------------------
+
+
+def _attach_capture(logger_name: str) -> list[logging.LogRecord]:
+    """Attach a list-recording handler to ``logger_name`` and return the list.
+
+    Direct handler attach (rather than ``caplog``) so the test does not
+    depend on ``propagate`` flags — the backend logs through its own
+    module-named child of ``podcast_script``.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = logging.getLogger(logger_name)
+    handler = _Capture()
+    handler.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    return records
+
+
+def _make_cache_aware_backend(
+    *,
+    cached: bool,
+    on_build: list[str] | None = None,
+) -> MlxWhisperBackend:
+    """Build a backend whose ``_is_cached`` is hard-wired to ``cached``.
+
+    ``_build_model`` records its invocation in ``on_build`` (if provided)
+    so callers can assert AC-US-5.1's ordering invariant: the notice
+    MUST be emitted before any heavy build path runs.
+    """
+
+    class _CacheAwareBackend(MlxWhisperBackend):
+        def _is_cached(self, model: str) -> bool:
+            return cached
+
+        def _build_model(self, model: str, device: str) -> object:
+            if on_build is not None:
+                on_build.append("build")
+            return object()
+
+    return _CacheAwareBackend()
+
+
+def test_load_emits_first_run_notice_on_cache_miss_AC_US_5_1() -> None:
+    """AC-US-5.1: when the model is not in the local cache,
+    :meth:`MlxWhisperBackend.load` MUST emit a single
+    ``level=info event=model_download model=<name> size_gb=<n>`` line
+    (locked shape per ADR-0012) so the user sees within 1 s of process
+    start that a multi-GB download is in progress (NFR-6).
+    """
+    records = _attach_capture("podcast_script.backends.mlx")
+    backend = _make_cache_aware_backend(cached=False)
+
+    backend.load(model="large-v3", device="cpu")
+
+    notices = [r for r in records if getattr(r, "event", None) == "model_download"]
+    assert len(notices) == 1
+    notice = notices[0]
+    assert notice.levelno == logging.INFO
+    assert getattr(notice, "model", None) == "large-v3"
+    assert getattr(notice, "size_gb", None) == "3"
+
+
+def test_load_notice_precedes_build_model_AC_US_5_1() -> None:
+    """AC-US-5.1 / NFR-6 ordering invariant: the notice MUST be emitted
+    BEFORE :meth:`MlxWhisperBackend._build_model` is called — that
+    method is where the heavy ``mlx_whisper`` import + HF download
+    triggers happen, and the 1-s budget is measured from process start.
+    Emitting after the download has begun would defeat the AC.
+    """
+    records = _attach_capture("podcast_script.backends.mlx")
+    build_calls: list[str] = []
+    notices_at_build_time: list[int] = []
+
+    class _OrderingBackend(MlxWhisperBackend):
+        def _is_cached(self, model: str) -> bool:
+            return False
+
+        def _build_model(self, model: str, device: str) -> object:
+            notices_at_build_time.append(
+                sum(1 for r in records if getattr(r, "event", None) == "model_download")
+            )
+            build_calls.append("build")
+            return object()
+
+    _OrderingBackend().load(model="large-v3", device="cpu")
+
+    assert build_calls == ["build"]
+    assert notices_at_build_time == [1], (
+        "model_download notice must fire BEFORE _build_model so the "
+        "AC-US-5.1 1-s budget holds even when HF download is slow"
+    )
+
+
+def test_load_silent_on_cache_hit_AC_US_5_2() -> None:
+    """AC-US-5.2: when the requested model is already cached, no
+    ``model_download`` notice is emitted. Subsequent runs after the
+    initial download stay silent so wrappers piping the tool don't see
+    a spurious download event on every invocation.
+    """
+    records = _attach_capture("podcast_script.backends.mlx")
+    backend = _make_cache_aware_backend(cached=True)
+
+    backend.load(model="large-v3", device="cpu")
+
+    notices = [r for r in records if getattr(r, "event", None) == "model_download"]
+    assert notices == []
+
+
+def test_load_skips_cache_check_on_repeat_call() -> None:
+    """ADR-0011 first-use site: a second :meth:`load` MUST short-circuit
+    before the cache check (and before any helper call). Otherwise the
+    AC-US-5.2 invariant could be violated for in-process re-use even
+    though the model was downloaded by the first call.
+    """
+    records = _attach_capture("podcast_script.backends.mlx")
+    cache_calls: list[str] = []
+
+    class _CountingCacheBackend(MlxWhisperBackend):
+        def _is_cached(self, model: str) -> bool:
+            cache_calls.append(model)
+            return False
+
+        def _build_model(self, model: str, device: str) -> object:
+            return object()
+
+    backend = _CountingCacheBackend()
+    backend.load(model="large-v3", device="cpu")
+    backend.load(model="large-v3", device="cpu")
+
+    assert cache_calls == ["large-v3"], (
+        "second load() must short-circuit before _is_cached re-runs"
+    )
+    notices = [r for r in records if getattr(r, "event", None) == "model_download"]
+    assert len(notices) == 1
+
+
+def test_default_is_cached_uses_huggingface_hub_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real ``_is_cached`` path: stub ``huggingface_hub.scan_cache_dir``
+    to return a synthetic cache containing ``mlx-community/whisper-large-v3``
+    and assert :meth:`_is_cached` returns ``True`` for ``large-v3`` and
+    ``False`` for ``tiny`` (not in the synthetic cache). The real lib is
+    consulted only here — POD-030 (Tier 2) covers the live HF surface.
+    """
+
+    class _FakeRepo:
+        def __init__(self, repo_id: str) -> None:
+            self.repo_id = repo_id
+
+    class _FakeCacheInfo:
+        def __init__(self, repos: list[_FakeRepo]) -> None:
+            self.repos = repos
+
+    fake_cache = _FakeCacheInfo([_FakeRepo("mlx-community/whisper-large-v3")])
+
+    import huggingface_hub
+
+    def _fake_scan(*_args: Any, **_kwargs: Any) -> _FakeCacheInfo:
+        return fake_cache
+
+    monkeypatch.setattr(huggingface_hub, "scan_cache_dir", _fake_scan)
+
+    backend = MlxWhisperBackend()
+    assert backend._is_cached("large-v3") is True
+    assert backend._is_cached("tiny") is False
+
+
+@pytest.mark.parametrize(
+    ("cached_repo_id", "requested_model", "expected"),
+    [
+        # Faster-whisper repos MUST NOT match the mlx cache: Systran's
+        # ``faster-whisper-tiny`` ends with ``faster-whisper-tiny``, not
+        # ``/whisper-tiny``, so the anchor disambiguates the two backends'
+        # caches even though both live under ~/.cache/huggingface.
+        ("Systran/faster-whisper-tiny", "tiny", False),
+        ("Systran/faster-whisper-large-v3", "large-v3", False),
+        # Canonical mlx-community repos MUST match the bare model name —
+        # this is the AC-US-5.2 silence path.
+        ("mlx-community/whisper-tiny", "tiny", True),
+        ("mlx-community/whisper-large-v3", "large-v3", True),
+        ("mlx-community/whisper-large-v3-turbo", "large-v3-turbo", True),
+        # Owner forks of an mlx-community model MUST also match (any
+        # owner/<...>/whisper-{model} suffix is valid).
+        ("some-fork/whisper-large-v3", "large-v3", True),
+        # Bare model requested, only a quantised variant cached: the
+        # bare model is genuinely missing on disk so the notice MUST
+        # fire — anchoring on ``/whisper-{model}`` keeps this False.
+        ("mlx-community/whisper-tiny-q4", "tiny", False),
+    ],
+)
+def test_default_is_cached_anchors_match_on_end_of_repo_id(
+    monkeypatch: pytest.MonkeyPatch,
+    cached_repo_id: str,
+    requested_model: str,
+    expected: bool,
+) -> None:
+    """Same anchor-on-end discipline as faster's ``_is_cached`` (ref:
+    PR #12 review): a substring match would let the faster-whisper repos
+    falsely report their mlx counterparts as cached. Anchoring on the
+    full ``/whisper-{model}`` suffix disambiguates the two backends'
+    caches sharing ``~/.cache/huggingface``.
+    """
+
+    class _FakeRepo:
+        def __init__(self, repo_id: str) -> None:
+            self.repo_id = repo_id
+
+    class _FakeCacheInfo:
+        def __init__(self, repos: list[_FakeRepo]) -> None:
+            self.repos = repos
+
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "scan_cache_dir",
+        lambda *_a, **_k: _FakeCacheInfo([_FakeRepo(cached_repo_id)]),
+    )
+
+    assert MlxWhisperBackend()._is_cached(requested_model) is expected
+
+
+def test_default_is_cached_returns_false_when_scan_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``huggingface_hub.scan_cache_dir`` raises (corrupt cache,
+    permission denied, etc.), ``_is_cached`` MUST return ``False`` — i.e.
+    err on the side of emitting the notice, never silently swallow a
+    multi-GB download. False negatives are tolerable; false positives
+    are not.
+    """
+    import huggingface_hub
+
+    def _raising_scan(*_args: Any, **_kwargs: Any) -> Any:
+        raise OSError("synthetic scan failure")
+
+    monkeypatch.setattr(huggingface_hub, "scan_cache_dir", _raising_scan)
+
+    assert MlxWhisperBackend()._is_cached("large-v3") is False
+
+
+def test_module_does_not_eagerly_import_huggingface_hub() -> None:
+    """ADR-0011: importing :mod:`podcast_script.backends.mlx` at CLI
+    startup MUST NOT trigger a ``huggingface_hub`` import — the cache
+    check is lazy too. Companion to the ``mlx_whisper`` lazy-boundary
+    test at the top of this file.
+    """
+    sys.modules.pop("podcast_script.backends.mlx", None)
+    sys.modules.pop("huggingface_hub", None)
+
+    importlib.import_module("podcast_script.backends.mlx")
+
+    assert "huggingface_hub" not in sys.modules

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -246,6 +246,73 @@ def test_transcribe_before_load_raises_model_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# AC-US-5.4 — network unreachable on first run → ModelError exit 5
+# ---------------------------------------------------------------------------
+
+
+def test_load_wraps_network_failure_in_model_error_AC_US_5_4() -> None:
+    """AC-US-5.4 (US-5, Must): when the network is unreachable on first
+    run and the model is not in the ``huggingface_hub`` cache, the tool
+    MUST exit with code 5 and a stderr message naming the model and the
+    failure mode. ``cli.py`` translates :class:`ModelError` (exit 5)
+    automatically; this test validates the wrap and the message shape
+    on the mlx-whisper branch (mirror of the faster-whisper assertion).
+
+    ``mlx_whisper.load_models.load_model`` ultimately calls
+    ``huggingface_hub`` for download + cache resolution and surfaces a
+    wide vocabulary of network-shaped exceptions (``httpx.ConnectError``,
+    ``hf_hub.errors.HfHubHTTPError``, raw ``OSError``, etc.). Any
+    non-``ImportError`` failure inside ``_build_model`` is wrapped —
+    robust to upstream API drift (R-17).
+    """
+    backend = _make_backend_with_build_error(
+        ConnectionError("Failed to resolve 'huggingface.co'"),
+    )
+
+    with pytest.raises(ModelError) as exc_info:
+        backend.load(model="large-v3", device="cpu")
+
+    msg = str(exc_info.value)
+    assert "large-v3" in msg, "ModelError message must name the model (AC-US-5.4)"
+    assert "Failed to resolve" in msg or "ConnectionError" in msg, (
+        "ModelError message must surface the upstream failure mode (AC-US-5.4)"
+    )
+    assert isinstance(exc_info.value.__cause__, ConnectionError), (
+        "Original exception MUST chain via __cause__ for debuggability"
+    )
+
+
+def test_load_wraps_oserror_disk_failure_in_model_error() -> None:
+    """Disk-shaped failures during model resolution (``huggingface_hub``
+    cache write, full disk, permission denied) MUST also surface as
+    :class:`ModelError` (exit 5). Same family of failures as AC-US-5.4
+    but on the local filesystem axis rather than the network.
+    """
+    backend = _make_backend_with_build_error(
+        OSError(28, "No space left on device"),
+    )
+
+    with pytest.raises(ModelError) as exc_info:
+        backend.load(model="tiny", device="cpu")
+
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert "tiny" in str(exc_info.value)
+
+
+def test_load_propagates_keyboard_interrupt_per_ADR_0014() -> None:
+    """ADR-0014: ``KeyboardInterrupt`` and ``SystemExit`` MUST propagate
+    untouched even when the broad ``Exception`` wrap is in place — Ctrl-C
+    is the user's contract; AC-US-5.3 resume / restart is on the user,
+    not us. Wrapping these would mis-translate them to exit 5 instead of
+    the standard 130 / requested code.
+    """
+    backend = _make_backend_with_build_error(KeyboardInterrupt())
+
+    with pytest.raises(KeyboardInterrupt):
+        backend.load(model="tiny", device="cpu")
+
+
+# ---------------------------------------------------------------------------
 # AC-US-5.1 / AC-US-5.2 — first-run model-download notice integration
 # ---------------------------------------------------------------------------
 

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -32,6 +32,7 @@ SAMPLE_RATE = 16_000
 def _silence_pcm(duration_s: float) -> npt.NDArray[np.float32]:
     return np.zeros(int(duration_s * SAMPLE_RATE), dtype=np.float32)
 
+
 # ---------------------------------------------------------------------------
 # ADR-0011 — module-level lazy-import boundary
 # ---------------------------------------------------------------------------

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -253,9 +253,7 @@ def test_load_skips_cache_check_on_repeat_call() -> None:
     backend.load(model="large-v3", device="cpu")
     backend.load(model="large-v3", device="cpu")
 
-    assert cache_calls == ["large-v3"], (
-        "second load() must short-circuit before _is_cached re-runs"
-    )
+    assert cache_calls == ["large-v3"], "second load() must short-circuit before _is_cached re-runs"
     notices = [r for r in records if getattr(r, "event", None) == "model_download"]
     assert len(notices) == 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pyyaml" },
-    { name = "setuptools" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/0f/581de94b64c5f2327a736270bc7e7a5f8fe5cf1ed56a2203b52de4d8986a/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4c0cbd46a23b8dc37ccdbd9b447cb5f7fadc361c90e9df17d82ca84b1f019986", size = 1257089, upload-time = "2026-02-04T06:11:32.442Z" },
@@ -666,6 +667,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -869,6 +882,18 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -878,6 +903,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
 ]
 
 [[package]]
@@ -980,6 +1018,72 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/47/5f33906cb03d6a378a697cd2d2641a26b37dea17ee3d9124d7e39e8eca01/mlx-0.31.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e5067aaf2be1f3d7bba5be52348775804f111173c1ed04639618fd713b1a530f", size = 584863, upload-time = "2026-04-22T03:14:38.211Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e7/a851a451b1327af9fb4df3991b9ae87d066b6f6630e854af55c288b0995a/mlx-0.31.2-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:edb9797db7d852477ca1c99708058654ee860d4148fe5765f0d55528e2b1aa22", size = 584860, upload-time = "2026-04-22T03:14:39.746Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/15/0d1dc0597644e5e7b011ca954ba0c47e13cd880a3b909b0c3f1b4d8bf8f1/mlx-0.31.2-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:51ca102db641b01e7cb083ce8ecb580e281530a141a7ca12544bb370641630ae", size = 584887, upload-time = "2026-04-22T03:14:41.585Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3f/888f8664d4f8e23a1363a5f50024be5216e199ab7ad0ba20988c7ed6d729/mlx-0.31.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:1b3fb0dda955b0d552ce57bdd6f42b3309ab21b067e40587d6848443d307e91f", size = 584796, upload-time = "2026-04-22T03:14:47.215Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/14/e9cd18b51f9e1dbcb060eec0fafc2d2428c8e1eacd9b0a02d7c5ce75b661/mlx-0.31.2-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:34b0171cd9eb5c43fdd82091f6135d6ccc5a065363a4a3e68fac64fb4e53d37c", size = 584790, upload-time = "2026-04-22T03:14:48.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/20/c6c5fb998c7834d094b2bfb9f003b5246cb270f0266da055c55546c34999/mlx-0.31.2-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:c05981684279a8935d58b0dde3ea5b02d210c3bad3319aa0e9934ec2df165752", size = 584795, upload-time = "2026-04-22T03:14:49.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
+    { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421, upload-time = "2026-04-22T03:14:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384, upload-time = "2026-04-22T03:14:57.439Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/69/fe3b783ebe999f3118234e1e940feb622518bfb1dea6ac5d13b1d36a8449/mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:b25385bcee18fc194092255b8b53b9a3d8489eb650e59160f1b57aadd07aa2dc", size = 40055588, upload-time = "2026-04-22T03:14:14.43Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5d/4c690d5b93c30ba002656c37363159d978705bf8eb801b8481840fb942c2/mlx_metal-0.31.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:e9d4e5fce6ca10a87a0e388597f99519ad594d09e674708b5312bd8bd4f5997d", size = 40053220, upload-time = "2026-04-22T03:14:18.048Z" },
+    { url = "https://files.pythonhosted.org/packages/99/82/11fd62a8d7a3e96e5c43220b17de0151e3f10101f8bb3b865f5bd9cdd074/mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:84ffb60ee503f03eb684f5fb168d5cff31e2a16b7f27c1731eaf7662bd6e9b46", size = 55792151, upload-time = "2026-04-22T03:14:22.059Z" },
+]
+
+[[package]]
+name = "mlx-whisper"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "mlx", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "more-itertools", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "numba", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "scipy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "tiktoken", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "torch", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "tqdm", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/b7/a35232812a2ccfffcb7614ba96a91338551a660a0e9815cee668bf5743f0/mlx_whisper-0.4.3-py3-none-any.whl", hash = "sha256:6b82b6597a994643a3e5496c7bc229a672e5ca308458455bfe276e76ae024489", size = 890544, upload-time = "2025-08-29T14:56:13.815Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "munkres"
 version = "1.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1056,6 +1160,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
 ]
 
 [[package]]
@@ -1388,6 +1508,7 @@ dependencies = [
     { name = "faster-whisper" },
     { name = "huggingface-hub" },
     { name = "inaspeechsegmenter" },
+    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "numpy" },
     { name = "rich" },
     { name = "typer" },
@@ -1405,6 +1526,7 @@ requires-dist = [
     { name = "faster-whisper", specifier = ">=1.0" },
     { name = "huggingface-hub", specifier = ">=0.24" },
     { name = "inaspeechsegmenter", specifier = "==0.7.6" },
+    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.4" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.7" },
     { name = "typer", specifier = ">=0.25.0" },
@@ -1601,6 +1723,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/28/b972a4d3df61e1d7bcf1b59fdb3cddef22f88b6be43f161bb41ebc0e4081/regex-2026.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c07ab8794fa929e58d97a0e1796b8b76f70943fa39df225ac9964615cf1f9d52", size = 490434, upload-time = "2026-04-03T20:53:40.219Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c8/3baa06d75c98c46d4cc4262b71fd2edb9062b5665e868bca57859dadf93a/regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76", size = 289628, upload-time = "2026-04-03T20:53:43.701Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/83/c4373bc5f31f2cf4b66f9b7c31005bd87fe66f0dce17701f7db4ee79ee29/regex-2026.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f5519042c101762509b1d717b45a69c0139d60414b3c604b81328c01bd1943", size = 490273, upload-time = "2026-04-03T20:54:11.202Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/92/4712b9fe6a33d232eeb1c189484b80c6c4b8422b90e766e1195d6e758207/regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7", size = 289487, upload-time = "2026-04-03T20:54:15.824Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1e/3a2b9672433bef02f5d39aa1143ca2c08f311c1d041c464a42be9ae648dc/regex-2026.4.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f94a11a9d05afcfcfa640e096319720a19cc0c9f7768e1a61fceee6a3afc6c7c", size = 494126, upload-time = "2026-04-03T20:54:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5f/eaa38092ce7a023656280f2341dbbd4ad5f05d780a70abba7bb4f4bea54c/regex-2026.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261c015b3e2ed0919157046d768774ecde57f03d8fa4ba78d29793447f70e717", size = 292334, upload-time = "2026-04-03T20:54:47.051Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f5/ed97c2dc47b5fbd4b73c0d7d75f9ebc8eca139f2bbef476bba35f28c0a77/regex-2026.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2da82d643fa698e5e5210e54af90181603d5853cf469f5eedf9bfc8f59b4b8c7", size = 490343, upload-time = "2026-04-03T20:55:15.241Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/5cfbfc97f3201a4d24b596a77957e092030dcc4205894bc035cedcfce62f/regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951", size = 289692, upload-time = "2026-04-03T20:55:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/06/35da85f9f217b9538b99cbb170738993bcc3b23784322decb77619f11502/regex-2026.4.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:97850d0638391bdc7d35dc1c1039974dcb921eaafa8cc935ae4d7f272b1d60b3", size = 494191, upload-time = "2026-04-03T20:55:51.258Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/f53b9ad17480b3ddd14c90da04bfb55ac6894b129e5dea87bcaf7d00e336/regex-2026.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7429f4e6192c11d659900c0648ba8776243bf396ab95558b8c51a345afeddde6", size = 292410, upload-time = "2026-04-03T20:55:55.736Z" },
 ]
 
 [[package]]
@@ -1830,8 +1970,33 @@ wheels = [
 
 [[package]]
 name = "setuptools"
+version = "81.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
+name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
@@ -1896,6 +2061,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tensorflow"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1915,7 +2092,8 @@ dependencies = [
     { name = "packaging" },
     { name = "protobuf" },
     { name = "requests" },
-    { name = "setuptools" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
     { name = "six" },
     { name = "termcolor" },
     { name = "typing-extensions" },
@@ -1963,6 +2141,23 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "requests", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
+]
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1986,6 +2181,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "fsspec", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jinja2", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "networkx", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "sympy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
+    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
+    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/46/4419098ed6d801750f26567b478fc185c3432e11e2cad712bc6b4c2ab0d0/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd", size = 80959460, upload-time = "2026-03-23T18:09:00.818Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Closes **POD-020** under **US-5** (Must, 5 pts) in sprint **SP-4** — finishes US-5: faster-whisper + first-run UX shipped via PRs #11/#12, this PR adds the Apple Silicon mirror so the pipeline runs end-to-end on macOS arm64.
- Adds `src/podcast_script/backends/mlx.py` — `MlxWhisperBackend` implementing the `WhisperBackend` Protocol (ADR-0003) with lazy `mlx_whisper` import (ADR-0011), the same `emit_first_run_notice_if_missing` wiring as the faster sibling (POD-021), and `ImportError` / network / disk / API-drift failures wrapped in `ModelError` exit 5 (ADR-0006).
- Adds `mlx-whisper>=0.4` as a darwin-arm64-only runtime dep via PEP 508 marker so Ubuntu CI's `uv sync --frozen` skips it cleanly (mlx-whisper ships no Linux wheels).

## Acceptance criteria satisfied
- [x] **AC-US-5.1** — `tests/test_mlx_backend.py::test_load_emits_first_run_notice_on_cache_miss_AC_US_5_1` + `…::test_load_notice_precedes_build_model_AC_US_5_1` (notice fires BEFORE `_build_model` so the NFR-6 1-s budget holds even when HF download is slow).
- [x] **AC-US-5.2** — `…::test_load_silent_on_cache_hit_AC_US_5_2` + `…::test_load_skips_cache_check_on_repeat_call` (in-process re-use also stays silent).
- [x] **AC-US-5.4** — `…::test_load_wraps_network_failure_in_model_error_AC_US_5_4` + `…::test_load_wraps_oserror_disk_failure_in_model_error` + `…::test_load_wraps_import_error_in_model_error` (network / disk / import all map to exit 5; original chained via `__cause__`).
- [x] **ADR-0014** — `…::test_load_propagates_keyboard_interrupt_per_ADR_0014` (Ctrl-C / `SystemExit` propagate untouched even with the broad `Exception` wrap).

## Implementation notes
- `_is_cached` anchors on **`/whisper-{model}`** (with the leading slash) — disambiguates `mlx-community/whisper-{model}` from `Systran/faster-whisper-{model}` sharing the same `~/.cache/huggingface` directory. Without the slash anchor, a faster-whisper cache entry would substring-match the bare model name and falsely suppress the AC-US-5.1 notice — same lesson as PR #12's `endswith` fix on the faster sibling.
- The seam pattern mirrors `backends/faster.py`: `_build_model` is the override-point for unit tests so the real `mlx_whisper` is never imported in the Tier 1 suite (POD-030 in SP-6 covers the live HF surface). `_run_inference` adapts `mlx_whisper.transcribe`'s segment dicts (`{"start", "end", "text"}`) into `_MlxSegmentTriple` objects so `transcribe()` consumes via attribute access — symmetric with the faster-whisper Protocol shape.
- `_MlxSegmentTriple` is a plain class (not `NamedTuple` / frozen dataclass) so its settable attributes satisfy the `_MlxSegment` Protocol's variance check under `mypy --strict` without declaring every attribute as a `@property`.
- `device` parameter accepted for Protocol symmetry with `FasterWhisperBackend` but unused: `mlx_whisper` always runs on the unified-memory Apple Silicon GPU.
- `mlx_whisper` ships no type stubs and is darwin-arm64-only — added a `[[tool.mypy.overrides]]` for `mlx_whisper.*` waiving missing-imports + missing-stubs uniformly so `mypy --strict` stays clean on both Ubuntu (not installed) and macOS (installed but untyped) CI lanes.

## Risks touched
- **R-1** (TF + MLX + faster-whisper combined install on Apple Silicon) — this PR is the first to actually pull `mlx-whisper` (and its transitive `mlx`, `torch`, `numba`, `tiktoken`) into `uv.lock`. SPK-1 in SP-1 was supposed to validate this on the macOS-14 runner ahead of time; macOS CI on this PR is the live verification.
- **R-17** (faster-whisper / mlx-whisper API drift) — unchanged: the Protocol abstraction confines any breakage to the single backend file; the broad `Exception` wrap in `load()` already maps API-shape changes to `ModelError` exit 5 instead of a stack trace.

## Documentation
- README (POD-036, SP-7) and CHANGELOG (POD-038, SP-8) are not yet in the repo per the SP plan — no edits this PR.
- ADR-0003 / ADR-0011 / ADR-0012 / ADR-0014 already cover the architectural decisions — no new ADR.
- Module + method docstrings in `backends/mlx.py` describe the wiring; comments on the `[[tool.mypy.overrides]]` and `_MlxSegmentTriple` plain-class choice explain the load-bearing constraints.

## Test plan
- [x] Tier 1 unit tests in `tests/test_mlx_backend.py` (22 new tests covering lazy-import, ImportError wrap, caching, first-run notice on miss + ordering invariant + silence on hit, repeat-call short-circuit, default `_is_cached` HF scan + repo-id anchor parametrization + scan-failure conservative fallback, `transcribe()` typed shape + lazy streaming + pre-load guard, AC-US-5.4 network / disk / KeyboardInterrupt branches).
- [x] Full pytest suite: **171 passed** (was 149 on `main`).
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy --strict` clean on `src/podcast_script` + `tests`.
- [ ] CI matrix (Ubuntu + macOS-14) — pending on push; macOS lane is the live SPK-1 / R-1 check (first PR pulling mlx-whisper into the lockfile).
- [ ] Reviewer to confirm the `_is_cached` anchor `/whisper-{model}` doesn't false-positive on any non-standard mlx fork they have cached locally (e.g. `*-q4` quantised variants — current matcher correctly returns False on those, so the notice fires conservatively).

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target.
- [x] Tests green locally (171/171).
- [x] Lint + format + type-check clean.
- [ ] CI matrix green (post-push).
- [ ] Maintainer self-review per Q7 — sanity-check on a real cold-cache `--backend mlx --model tiny` run is **deferred to POD-017** (`select_backend`, also SP-4) which is the first task that wires the mlx backend into the CLI.
- [ ] Docs (README/CHANGELOG): owned by POD-036/POD-038, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)