### PR TITLE
feat(POD-022): refuse-overwrite gate + missing-parent guard in CLI (US-6)

### DIFF
--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Annotated
 
 import typer
 
-from .errors import PodcastScriptError, UsageError
+from .errors import InputIOError, OutputExistsError, PodcastScriptError, UsageError
 from .logging_setup import Verbosity, configure
 from .segment import Segment
 
@@ -139,6 +139,35 @@ def _levenshtein(a: str, b: str) -> int:
             current.append(min(insert, delete, substitute))
         previous = current
     return previous[-1]
+
+
+def _check_output_path(resolved_output: Path, *, force: bool) -> None:
+    """Pre-flight gate for the resolved output path (POD-022, US-6).
+
+    Two ACs are enforced before the pipeline starts so a misconfigured
+    invocation costs nothing more than an exit code:
+
+    * AC-US-6.4 — parent directory must already exist (the cli MUST NOT
+      create it); raises :class:`InputIOError` (exit 3). Holds with or
+      without ``--force``.
+    * AC-US-6.1 — if the path already exists and ``--force``/``-f`` was
+      not passed, raise :class:`OutputExistsError` (exit 6); the prior
+      file is therefore left untouched.
+
+    Order matters: a missing parent makes the existence check
+    meaningless, so it is reported first and only then is overwrite
+    refused.
+    """
+    parent = resolved_output.parent
+    if not parent.is_dir():
+        raise InputIOError(
+            f"output parent directory does not exist: {parent}; "
+            "create it before re-running, or pass -o/--output with an existing parent"
+        )
+    if resolved_output.exists() and not force:
+        raise OutputExistsError(
+            f"refusing to overwrite existing file {resolved_output}; pass --force / -f to opt in"
+        )
 
 
 def _resolve_verbosity(verbose: bool, quiet: bool, debug: bool) -> Verbosity:
@@ -313,6 +342,7 @@ def main(
         validate_lang(lang)
 
         resolved_output = output if output is not None else input_path.with_suffix(".md")
+        _check_output_path(resolved_output, force=force)
         _run_pipeline(
             input_path=input_path,
             output_path=resolved_output,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -243,3 +243,177 @@ class TestCliGrammarSurface:
             ],
         )
         assert result.exit_code == 0, f"stderr={result.stderr!r}"
+
+
+class TestOutputExistsCheck:
+    """AC-US-6.1 — refuse to overwrite an existing output without ``--force``.
+
+    POD-022: the cli rejects a run before the pipeline starts when the
+    resolved output path already exists and ``--force``/``-f`` was not
+    passed. The pipeline never runs in this branch, so no monkeypatch is
+    needed — exit 6 must surface from the pre-flight gate.
+    """
+
+    def test_existing_output_without_force_exits_6(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        output_file = tmp_path / "episode.md"
+        output_file.write_text("hand-edited transcript\n", encoding="utf-8")
+        result = runner.invoke(app, [str(input_file), "--lang", "es"])
+        assert result.exit_code == 6, f"stderr={result.stderr!r}"
+
+    def test_existing_output_message_names_file_and_suggests_force(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        output_file = tmp_path / "episode.md"
+        output_file.write_text("hand-edited transcript\n", encoding="utf-8")
+        result = runner.invoke(app, [str(input_file), "--lang", "es"])
+        # AC-US-6.1: stderr names the existing file and instructs --force/-f.
+        assert "episode.md" in result.stderr, f"stderr={result.stderr!r}"
+        assert "--force" in result.stderr, f"stderr={result.stderr!r}"
+
+    def test_existing_output_unchanged_after_refused_run(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        output_file = tmp_path / "episode.md"
+        prior = "hand-edited transcript\n"
+        output_file.write_text(prior, encoding="utf-8")
+        runner.invoke(app, [str(input_file), "--lang", "es"])
+        # AC-US-6.1: "episode.md is left unchanged."
+        assert output_file.read_text(encoding="utf-8") == prior
+
+    def test_existing_output_emits_logfmt_event_output_exists(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # ADR-0006 + ADR-0008: every typed-error exit logs the locked
+        # ``event`` token (here ``output_exists``, NFR-9 exit 6) so users
+        # can grep one fixed key on stderr.
+        input_file = _touch(tmp_path, "episode.mp3")
+        output_file = tmp_path / "episode.md"
+        output_file.write_text("hand-edited\n", encoding="utf-8")
+        result = runner.invoke(app, [str(input_file), "--lang", "es"])
+        assert "event=output_exists" in result.stderr
+        assert "code=6" in result.stderr
+
+    def test_explicit_output_via_dash_o_also_checked(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # The check applies to the *resolved* output path, not just the
+        # default ``<input-stem>.md`` — ``-o``/``--output`` flows through
+        # the same gate.
+        input_file = _touch(tmp_path, "episode.mp3")
+        custom = tmp_path / "custom.md"
+        custom.write_text("hand-edited\n", encoding="utf-8")
+        result = runner.invoke(
+            app, [str(input_file), "--lang", "es", "-o", str(custom)]
+        )
+        assert result.exit_code == 6, f"stderr={result.stderr!r}"
+
+    def test_force_bypasses_gate(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # POD-022 just opens the gate; POD-023 will lock down the
+        # "actually overwrites" + atomic-preservation paths end-to-end
+        # (AC-US-6.2 / AC-US-6.3). Here we only assert that ``--force``
+        # avoids the exit-6 refusal — pipeline is stubbed.
+        from podcast_script import cli as cli_module
+
+        monkeypatch.setattr(cli_module, "_run_pipeline", lambda **_: None)
+
+        input_file = _touch(tmp_path, "episode.mp3")
+        output_file = tmp_path / "episode.md"
+        output_file.write_text("hand-edited\n", encoding="utf-8")
+        result = runner.invoke(
+            app, [str(input_file), "--lang", "es", "--force"]
+        )
+        assert result.exit_code == 0, f"stderr={result.stderr!r}"
+        # Short alias ``-f`` is checked by ``test_locked_short_flags_are_accepted``.
+
+    def test_no_pre_existing_output_runs_pipeline(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Sanity: when the output doesn't exist the gate is a no-op.
+        from podcast_script import cli as cli_module
+
+        called: list[Path] = []
+        monkeypatch.setattr(
+            cli_module,
+            "_run_pipeline",
+            lambda **kw: called.append(kw["output_path"]),
+        )
+
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(app, [str(input_file), "--lang", "es"])
+        assert result.exit_code == 0
+        assert called == [tmp_path / "episode.md"]
+
+
+class TestMissingParentDir:
+    """AC-US-6.4 — resolved output's parent directory does not exist → exit 3.
+
+    Holds with or without ``--force`` (the SRS spelling). The cli MUST NOT
+    create the missing parent silently.
+    """
+
+    def test_missing_parent_exits_3(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        output_path = tmp_path / "does-not-exist" / "episode.md"
+        result = runner.invoke(
+            app, [str(input_file), "--lang", "es", "-o", str(output_path)]
+        )
+        assert result.exit_code == 3, f"stderr={result.stderr!r}"
+
+    def test_missing_parent_message_names_directory(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        output_path = tmp_path / "does-not-exist" / "episode.md"
+        result = runner.invoke(
+            app, [str(input_file), "--lang", "es", "-o", str(output_path)]
+        )
+        assert "does-not-exist" in result.stderr, f"stderr={result.stderr!r}"
+
+    def test_missing_parent_creates_no_directories(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        missing_parent = tmp_path / "does-not-exist"
+        output_path = missing_parent / "episode.md"
+        runner.invoke(
+            app, [str(input_file), "--lang", "es", "-o", str(output_path)]
+        )
+        assert not missing_parent.exists(), "cli must not create the missing parent"
+
+    def test_missing_parent_with_force_still_exits_3(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # SRS AC-US-6.4: "with or without --force".
+        input_file = _touch(tmp_path, "episode.mp3")
+        output_path = tmp_path / "does-not-exist" / "episode.md"
+        result = runner.invoke(
+            app,
+            [str(input_file), "--lang", "es", "-f", "-o", str(output_path)],
+        )
+        assert result.exit_code == 3, f"stderr={result.stderr!r}"
+
+    def test_missing_parent_emits_logfmt_event_input_io_error(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        input_file = _touch(tmp_path, "episode.mp3")
+        output_path = tmp_path / "does-not-exist" / "episode.md"
+        result = runner.invoke(
+            app, [str(input_file), "--lang", "es", "-o", str(output_path)]
+        )
+        assert "event=input_io_error" in result.stderr
+        assert "code=3" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,9 +254,7 @@ class TestOutputExistsCheck:
     needed — exit 6 must surface from the pre-flight gate.
     """
 
-    def test_existing_output_without_force_exits_6(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_existing_output_without_force_exits_6(self, runner: CliRunner, tmp_path: Path) -> None:
         input_file = _touch(tmp_path, "episode.mp3")
         output_file = tmp_path / "episode.md"
         output_file.write_text("hand-edited transcript\n", encoding="utf-8")
@@ -307,9 +305,7 @@ class TestOutputExistsCheck:
         input_file = _touch(tmp_path, "episode.mp3")
         custom = tmp_path / "custom.md"
         custom.write_text("hand-edited\n", encoding="utf-8")
-        result = runner.invoke(
-            app, [str(input_file), "--lang", "es", "-o", str(custom)]
-        )
+        result = runner.invoke(app, [str(input_file), "--lang", "es", "-o", str(custom)])
         assert result.exit_code == 6, f"stderr={result.stderr!r}"
 
     def test_force_bypasses_gate(
@@ -329,9 +325,7 @@ class TestOutputExistsCheck:
         input_file = _touch(tmp_path, "episode.mp3")
         output_file = tmp_path / "episode.md"
         output_file.write_text("hand-edited\n", encoding="utf-8")
-        result = runner.invoke(
-            app, [str(input_file), "--lang", "es", "--force"]
-        )
+        result = runner.invoke(app, [str(input_file), "--lang", "es", "--force"])
         assert result.exit_code == 0, f"stderr={result.stderr!r}"
         # Short alias ``-f`` is checked by ``test_locked_short_flags_are_accepted``.
 
@@ -364,14 +358,10 @@ class TestMissingParentDir:
     create the missing parent silently.
     """
 
-    def test_missing_parent_exits_3(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_missing_parent_exits_3(self, runner: CliRunner, tmp_path: Path) -> None:
         input_file = _touch(tmp_path, "episode.mp3")
         output_path = tmp_path / "does-not-exist" / "episode.md"
-        result = runner.invoke(
-            app, [str(input_file), "--lang", "es", "-o", str(output_path)]
-        )
+        result = runner.invoke(app, [str(input_file), "--lang", "es", "-o", str(output_path)])
         assert result.exit_code == 3, f"stderr={result.stderr!r}"
 
     def test_missing_parent_message_names_directory(
@@ -379,20 +369,14 @@ class TestMissingParentDir:
     ) -> None:
         input_file = _touch(tmp_path, "episode.mp3")
         output_path = tmp_path / "does-not-exist" / "episode.md"
-        result = runner.invoke(
-            app, [str(input_file), "--lang", "es", "-o", str(output_path)]
-        )
+        result = runner.invoke(app, [str(input_file), "--lang", "es", "-o", str(output_path)])
         assert "does-not-exist" in result.stderr, f"stderr={result.stderr!r}"
 
-    def test_missing_parent_creates_no_directories(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_missing_parent_creates_no_directories(self, runner: CliRunner, tmp_path: Path) -> None:
         input_file = _touch(tmp_path, "episode.mp3")
         missing_parent = tmp_path / "does-not-exist"
         output_path = missing_parent / "episode.md"
-        runner.invoke(
-            app, [str(input_file), "--lang", "es", "-o", str(output_path)]
-        )
+        runner.invoke(app, [str(input_file), "--lang", "es", "-o", str(output_path)])
         assert not missing_parent.exists(), "cli must not create the missing parent"
 
     def test_missing_parent_with_force_still_exits_3(
@@ -412,8 +396,6 @@ class TestMissingParentDir:
     ) -> None:
         input_file = _touch(tmp_path, "episode.mp3")
         output_path = tmp_path / "does-not-exist" / "episode.md"
-        result = runner.invoke(
-            app, [str(input_file), "--lang", "es", "-o", str(output_path)]
-        )
+        result = runner.invoke(app, [str(input_file), "--lang", "es", "-o", str(output_path)])
         assert "event=input_io_error" in result.stderr
         assert "code=3" in result.stderr


### PR DESCRIPTION
## Summary
- Refuse to overwrite an existing output file when `--force`/`-f` is not passed (exit 6, `event=output_exists`)
- Reject runs when the resolved output's parent directory does not exist (exit 3, `event=input_io_error`), holds with or without `--force`
- Both checks fire before the pipeline starts so a misconfigured invocation costs only the exit code
- Closes POD-022 (story US-6, sprint SP-4 of `PROJECT_PLAN.md`). POD-023 will follow with AC-US-6.2 / AC-US-6.3 end-to-end + failure-injection tests.

## Acceptance criteria satisfied
- [x] **AC-US-6.1** — existing output, no `--force` → exit 6; stderr names file + suggests `--force`/`-f`; prior content unchanged. Covered by `tests/test_cli.py::TestOutputExistsCheck` (7 tests).
- [x] **AC-US-6.4** — output's parent directory missing → exit 3; stderr names the missing parent; no directories created; holds with or without `--force`. Covered by `tests/test_cli.py::TestMissingParentDir` (5 tests).

## Architectural constraints honored
- **ADR-0006** — typed exception hierarchy; cli is the only translator to `typer.Exit(code)`. Reuses the existing `OutputExistsError` (exit 6) and `InputIOError` (exit 3) classes from `errors.py`.
- **ADR-0005** — atomic write (POD-009) already preserves the prior file on failure; POD-023 will pin AC-US-6.3 with a failure-injection test.
- **ADR-0012** — locked logfmt event tokens (`output_exists`, `input_io_error`) emitted via the existing catch-and-translate handler in `main()`; tests assert both `event=` and `code=` keys.

## Documentation updated
- README — n/a, deferred to POD-036 (SP-7).
- CHANGELOG — n/a, deferred to POD-038 (SP-8).
- `--help` exit-code epilog + `--force` help text — already correct (POD-006 wrote them forward-looking); verified locally.

## Test plan
- [x] `uv run pytest`: 183 passed locally (171 on `main` + 12 new)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy --strict` clean
- [ ] CI matrix (Ubuntu + macOS-14) green on push

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target
- [x] Tests green
- [x] Docs current (no user-facing docs exist yet for v0.1.0)
- [ ] Stakeholder signoff at sprint review (post-merge)