### PR TITLE
feat(POD-016): C-Config TOML load + CLI merge (US-4)

### DIFF
--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -1,15 +1,23 @@
-"""CLI entrypoint for podcast-script (POD-006).
+"""CLI entrypoint for podcast-script (POD-006 + POD-016).
 
-Owns the typer-based ``--lang`` validation surface and the ADR-0006
-exception → ``typer.Exit(code)`` translation. Per ADR-0006, this module
-is the *only* place that converts :class:`PodcastScriptError` subclasses
-into exit codes; stages elsewhere raise the typed exceptions and never
-call ``sys.exit`` directly.
+Owns the typer surface and the ADR-0006 exception → ``typer.Exit(code)``
+translation. Per ADR-0006, this module is the *only* place that converts
+:class:`PodcastScriptError` subclasses into exit codes; stages elsewhere
+raise the typed exceptions and never call ``sys.exit`` directly.
 
-The ``--lang`` curated set is locked at SRS §1.7 / Q11; unknown codes are
-rejected with a "did you mean?" suggestion via Levenshtein distance ≤ 2
-(AC-US-1.5). Missing ``--lang`` (and, once POD-016 lands, no config
-fallback) is also a usage error (AC-US-4.3).
+The ``--lang`` curated set is locked at SRS §1.7 / Q11; the validator —
+including the Levenshtein-≤-2 did-you-mean (AC-US-1.5) — lives in
+:mod:`.config` and is re-exported here for backward compatibility with
+callers that imported the cli helpers directly.
+
+POD-016 inverts the previous "CLI wins implicitly" model: the CLI
+collects each flag as ``None`` when the user didn't pass it, hands the
+dict (plus the parsed TOML defaults from
+:data:`~podcast_script.config.DEFAULT_CONFIG_PATH`) to
+:func:`~podcast_script.config.merge`, and runs the pipeline against the
+merged :class:`~podcast_script.config.Config`. Defaults (``model =
+large-v3``, ``device = auto``, …) live in :mod:`.config`, not here, so
+TOML can show through any flag the user didn't type (AC-US-4.1).
 
 POD-008 wired :class:`~podcast_script.pipeline.Pipeline` behind
 :func:`_run_pipeline`; the cli is the composition root that hands real
@@ -27,8 +35,10 @@ from typing import TYPE_CHECKING, Annotated
 
 import typer
 
-from .errors import InputIOError, OutputExistsError, PodcastScriptError, UsageError
-from .logging_setup import Verbosity, configure
+from . import config as _config
+from .config import SUPPORTED_LANGS, validate_lang
+from .errors import InputIOError, OutputExistsError, PodcastScriptError
+from .logging_setup import configure
 from .segment import Segment
 
 if TYPE_CHECKING:
@@ -36,15 +46,12 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from .backends.base import TranscribedSegment
+    from .logging_setup import Verbosity
     from .render import TimestampFormat
 
-SUPPORTED_LANGS: tuple[str, ...] = ("es", "en", "pt", "fr", "de", "it", "ca", "eu")
-"""The eight v1 ``--lang`` codes (SRS §1.7). Frozen for v1.0.0; expanding
-this set is a SemVer-major event because it changes the CLI contract."""
-
-_DID_YOU_MEAN_MAX_DISTANCE = 2
-"""Per AC-US-1.5: suggest a code only when its Levenshtein distance to the
-typo is ≤ 2. Larger distances would surface unrelated codes as 'suggestions'."""
+# Re-exported so existing imports (``from podcast_script.cli import
+# SUPPORTED_LANGS, validate_lang``) keep working post-POD-016.
+__all__ = ["SUPPORTED_LANGS", "app", "validate_lang"]
 
 # Exit-code table required in --help by SRS §9.1 (line 430): "lists every
 # flag, the eight supported --lang codes, AND the documented exit-code
@@ -72,73 +79,6 @@ app = typer.Typer(
     pretty_exceptions_show_locals=False,
     rich_markup_mode=None,
 )
-
-
-def validate_lang(code: str) -> None:
-    """Validate ``code`` against the curated v1 ``--lang`` set.
-
-    Raises :class:`UsageError` (exit 2) if ``code`` is not in
-    :data:`SUPPORTED_LANGS`. The error message lists all supported codes
-    and, when the typo is within Levenshtein distance 2 of a supported
-    code, appends a ``did you mean `<closest>`?`` suggestion.
-    """
-    if code in SUPPORTED_LANGS:
-        return
-
-    supported = ", ".join(SUPPORTED_LANGS)
-    suggestion = _closest_supported_lang(code)
-    base = f"unknown --lang {code!r}; supported: {supported}"
-    if suggestion is not None:
-        raise UsageError(f"{base}; did you mean `{suggestion}`?")
-    raise UsageError(base)
-
-
-def _missing_lang_error() -> UsageError:
-    supported = ", ".join(SUPPORTED_LANGS)
-    return UsageError(f"--lang is required (e.g. --lang es). Supported: {supported}")
-
-
-def _closest_supported_lang(code: str) -> str | None:
-    """Return the closest supported code within ≤ 2 edits, or ``None``.
-
-    Ties are broken by :data:`SUPPORTED_LANGS` order — i.e. ``es`` wins
-    over ``en`` if both are equidistant — which makes the suggestion
-    deterministic across runs.
-    """
-    best: tuple[int, str] | None = None
-    for candidate in SUPPORTED_LANGS:
-        distance = _levenshtein(code, candidate)
-        if distance > _DID_YOU_MEAN_MAX_DISTANCE:
-            continue
-        if best is None or distance < best[0]:
-            best = (distance, candidate)
-    return best[1] if best is not None else None
-
-
-def _levenshtein(a: str, b: str) -> int:
-    """Standard Levenshtein edit distance.
-
-    Implemented inline rather than via a third-party ``rapidfuzz``-style
-    dep because ADR-0013 forbids new runtime deps for v1; the cost on
-    2-to-~8-character strings is negligible.
-    """
-    if a == b:
-        return 0
-    if not a:
-        return len(b)
-    if not b:
-        return len(a)
-
-    previous = list(range(len(b) + 1))
-    for i, ca in enumerate(a, start=1):
-        current = [i]
-        for j, cb in enumerate(b, start=1):
-            insert = current[j - 1] + 1
-            delete = previous[j] + 1
-            substitute = previous[j - 1] + (ca != cb)
-            current.append(min(insert, delete, substitute))
-        previous = current
-    return previous[-1]
 
 
 def _check_output_path(resolved_output: Path, *, force: bool) -> None:
@@ -304,11 +244,14 @@ def main(
         ),
     ] = False,
     model: Annotated[
-        str,
+        str | None,
         typer.Option(
-            "--model", help="Whisper model: tiny|base|small|medium|large-v3|large-v3-turbo."
+            "--model",
+            help=(
+                "Whisper model: tiny|base|small|medium|large-v3|large-v3-turbo. Default: large-v3."
+            ),
         ),
-    ] = "large-v3",
+    ] = None,
     backend: Annotated[
         str | None,
         typer.Option(
@@ -317,8 +260,9 @@ def main(
         ),
     ] = None,
     device: Annotated[
-        str, typer.Option("--device", help="Compute device: auto|cpu|cuda|mps.")
-    ] = "auto",
+        str | None,
+        typer.Option("--device", help="Compute device: auto|cpu|cuda|mps. Default: auto."),
+    ] = None,
     verbose: Annotated[
         bool, typer.Option("-v", "--verbose", help="Enable debug-level logs.")
     ] = False,
@@ -337,20 +281,35 @@ def main(
     log = configure(verbosity, progress=None)
 
     try:
-        if lang is None:
-            raise _missing_lang_error()
-        validate_lang(lang)
+        # POD-016 — load TOML defaults from the locked path (None = absent)
+        # then merge with whatever the user typed on argv. ``cli_overrides``
+        # carries every flag value as-is; entries with ``None`` mean
+        # "user didn't pass this flag" and let TOML / built-in defaults
+        # show through (AC-US-4.1). CLI values that *are* set win
+        # (AC-US-4.2). Missing lang anywhere → AC-US-4.3.
+        toml_defaults = _config.load_toml_defaults(_config.DEFAULT_CONFIG_PATH)
+        cli_overrides: dict[str, object] = {
+            "input": input_path,
+            "output": output,
+            "lang": lang,
+            "model": model,
+            "backend": backend,
+            "device": device,
+            "force": force,
+            "verbosity": verbosity,
+        }
+        cfg = _config.merge(toml_defaults=toml_defaults, cli_overrides=cli_overrides)
 
-        resolved_output = output if output is not None else input_path.with_suffix(".md")
-        _check_output_path(resolved_output, force=force)
+        resolved_output = cfg.output if cfg.output is not None else cfg.input.with_suffix(".md")
+        _check_output_path(resolved_output, force=cfg.force)
         _run_pipeline(
-            input_path=input_path,
+            input_path=cfg.input,
             output_path=resolved_output,
-            lang=lang,
-            model=model,
-            backend=backend,
-            device=device,
-            force=force,
+            lang=cfg.lang,
+            model=cfg.model,
+            backend=cfg.backend,
+            device=cfg.device,
+            force=cfg.force,
             debug=debug,
         )
     except PodcastScriptError as exc:

--- a/src/podcast_script/config.py
+++ b/src/podcast_script/config.py
@@ -162,21 +162,36 @@ def merge(
     return cfg
 
 
+def validate_lang(code: str) -> None:
+    """Validate ``code`` against the curated v1 ``--lang`` set.
+
+    Raises :class:`UsageError` (exit 2) if ``code`` is not in
+    :data:`SUPPORTED_LANGS`. The error message lists all supported codes
+    and, when the typo is within Levenshtein distance 2 of a supported
+    code, appends a ``did you mean `<closest>`?`` suggestion. Used both
+    by the CLI's standalone ``--lang`` validator (AC-US-1.5) and by
+    :func:`validate` for the config-loaded path (AC-US-4.4) — keeping
+    the message shape identical across both.
+    """
+    if code in SUPPORTED_LANGS:
+        return
+    supported = ", ".join(SUPPORTED_LANGS)
+    suggestion = _closest_supported_lang(code)
+    base = f"unknown --lang {code!r}; supported: {supported}"
+    if suggestion is not None:
+        raise UsageError(f"{base}; did you mean `{suggestion}`?")
+    raise UsageError(base)
+
+
 def validate(cfg: Config) -> None:
     """Validate every whitelisted field on ``cfg``; raise on any miss.
 
-    ``lang`` uses the same did-you-mean machinery as :mod:`.cli` so a
-    config-loaded typo (AC-US-4.4) gets the same hint as a CLI typo
+    ``lang`` delegates to :func:`validate_lang` so a config-loaded typo
+    (AC-US-4.4) gets the same did-you-mean hint as a CLI typo
     (AC-US-1.5). The other three whitelists raise plain messages —
     they're rare enough that did-you-mean noise isn't worth the LoC.
     """
-    if cfg.lang not in SUPPORTED_LANGS:
-        supported = ", ".join(SUPPORTED_LANGS)
-        suggestion = _closest_supported_lang(cfg.lang)
-        base = f"unknown lang {cfg.lang!r}; supported: {supported}"
-        if suggestion is not None:
-            raise UsageError(f"{base}; did you mean `{suggestion}`?")
-        raise UsageError(base)
+    validate_lang(cfg.lang)
 
     if cfg.model not in SUPPORTED_MODELS:
         raise UsageError(f"unknown model {cfg.model!r}; supported: {', '.join(SUPPORTED_MODELS)}")
@@ -254,4 +269,5 @@ __all__ = [
     "load_toml_defaults",
     "merge",
     "validate",
+    "validate_lang",
 ]

--- a/src/podcast_script/config.py
+++ b/src/podcast_script/config.py
@@ -147,9 +147,14 @@ def merge(
     if "lang" not in merged:
         raise _missing_lang_error()
 
-    merged["input"] = Path(merged["input"])
+    # ADR-0013 §Decision step 5: coerce path-typed fields with
+    # ``Path(str).expanduser().resolve()`` so a TOML ``output =
+    # "~/transcripts/ep.md"`` (or a relative path) reaches the pipeline
+    # already absolute and tilde-expanded. Without this, downstream
+    # checks like ``_check_output_path`` fail on the unexpanded ``~``.
+    merged["input"] = Path(merged["input"]).expanduser().resolve()
     if merged["output"] is not None:
-        merged["output"] = Path(merged["output"])
+        merged["output"] = Path(merged["output"]).expanduser().resolve()
 
     try:
         cfg = Config(**merged)
@@ -222,9 +227,7 @@ def _closest_supported_lang(code: str) -> str | None:
 
     Ties break by :data:`SUPPORTED_LANGS` order so the suggestion is
     deterministic across runs (e.g. ``es`` wins over ``en`` if both are
-    equidistant). Mirrors the cli helper of the same name; the
-    duplication is small enough not to warrant a shared helper module
-    until a third caller appears.
+    equidistant).
     """
     best: tuple[int, str] | None = None
     for candidate in SUPPORTED_LANGS:

--- a/src/podcast_script/config.py
+++ b/src/podcast_script/config.py
@@ -1,6 +1,257 @@
 """C-Config: TOML defaults + CLI merge → ``Config`` dataclass (POD-016).
 
-Skeleton only — implementation lands in the TDD green steps.
+Implements ADR-0013: stdlib :mod:`tomllib` reads
+``~/.config/podcast-script/config.toml`` (or any path the CLI hands
+us); :func:`merge` overlays CLI flags on top of those defaults with
+**CLI-wins** precedence (AC-US-4.2); :func:`validate` re-runs the same
+``--lang`` validation against the merged value regardless of source so a
+config-loaded ``lang = "ja"`` is rejected just as harshly as
+``--lang ja`` would be (AC-US-4.4 / AC-US-1.5).
+
+Defaults live here, not in :mod:`.cli`, because the CLI must be able to
+pass ``None`` for "user didn't set this flag" so the TOML value can show
+through. Hardcoding ``model="large-v3"`` in the CLI signature would make
+that field win over TOML even when the user typed nothing.
+
+Per ADR-0013 the surface is small (~120 LOC); we keep validation manual
+rather than declarative because the field set is tiny and low-churn.
 """
 
 from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, get_args
+
+from .errors import UsageError
+from .logging_setup import Verbosity
+
+SUPPORTED_LANGS: tuple[str, ...] = ("es", "en", "pt", "fr", "de", "it", "ca", "eu")
+"""The eight v1 language codes locked in SRS §1.7. Mirrors
+:data:`podcast_script.cli.SUPPORTED_LANGS`; the cli module re-exports
+this so callers that haven't moved to ``Config`` yet keep working."""
+
+SUPPORTED_MODELS: tuple[str, ...] = (
+    "tiny",
+    "base",
+    "small",
+    "medium",
+    "large-v3",
+    "large-v3-turbo",
+)
+"""Whisper model names recognised in v1.0.0. Matches the size table in
+``backends/base.MODEL_SIZES_GB`` so first-run notice and validation
+agree on which models exist."""
+
+SUPPORTED_BACKENDS: tuple[str, ...] = ("auto", "faster-whisper", "mlx-whisper")
+"""``auto`` defers to :func:`select_backend` (POD-017, lands next).
+The two concrete names are the published CLI surface."""
+
+SUPPORTED_DEVICES: tuple[str, ...] = ("auto", "cpu", "cuda", "mps")
+"""``auto`` lets the backend pick; the other three match the hardware
+classes the project supports (CPU on any host, CUDA on Linux+NVIDIA,
+MPS on Apple Silicon via mlx-whisper)."""
+
+_DID_YOU_MEAN_MAX_DISTANCE = 2
+"""Per AC-US-1.5: only suggest a code within ≤ 2 edits of the typo.
+Larger distances surface unrelated codes and confuse more than they
+help."""
+
+DEFAULT_CONFIG_PATH: Path = Path.home() / ".config" / "podcast-script" / "config.toml"
+"""XDG-style location used when the CLI doesn't pass an explicit path.
+Per SRS §1.3, env-var overrides are out of scope for v1 — keeping the
+location hardcoded is deliberate."""
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Immutable run-configuration for one CLI invocation (ADR-0013).
+
+    Constructed by :func:`merge` from ``(toml_defaults, cli_overrides)``;
+    consumers downstream (cli composition root, pipeline) read the
+    fields directly. ``frozen=True`` blocks accidental in-flight mutation
+    across stages; ``slots=True`` keeps the in-memory footprint flat.
+    """
+
+    input: Path
+    output: Path | None
+    lang: str
+    model: str
+    backend: str
+    device: str
+    force: bool
+    verbosity: Verbosity
+
+
+# Built-in defaults — applied when neither TOML nor CLI sets the field.
+# Kept as a private dict (not class defaults on :class:`Config`) so that
+# ``Config(**merged)`` is honest about which fields the merge supplied
+# vs. which it left to the dataclass to fill in.
+_BUILTIN_DEFAULTS: dict[str, Any] = {
+    "output": None,
+    "model": "large-v3",
+    "backend": "auto",
+    "device": "auto",
+    "force": False,
+    "verbosity": "normal",
+}
+
+
+def load_toml_defaults(path: Path) -> dict[str, Any]:
+    """Read ``path`` and return its top-level table as a plain ``dict``.
+
+    Returns an empty dict when ``path`` does not exist — this is the
+    *normal* case for users who haven't created a config file. Callers
+    therefore never need to special-case "no config" and can blindly
+    spread the result into :func:`merge`.
+
+    Raises :class:`UsageError` (exit 2) on malformed TOML so a typo in
+    the user's config produces a clean message rather than a stack
+    trace bubbling out of :mod:`tomllib`.
+    """
+    if not path.exists():
+        return {}
+    try:
+        with path.open("rb") as fh:
+            return tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise UsageError(f"invalid TOML in {path}: {exc}") from exc
+
+
+def merge(
+    *,
+    toml_defaults: dict[str, Any],
+    cli_overrides: dict[str, Any],
+) -> Config:
+    """Merge ``toml_defaults`` and ``cli_overrides`` into a validated ``Config``.
+
+    Precedence (lowest-wins-first → highest-wins-last):
+    1. :data:`_BUILTIN_DEFAULTS` for fields neither side sets.
+    2. ``toml_defaults`` (parsed config file).
+    3. ``cli_overrides``, but only entries whose value is not ``None`` —
+       a ``None`` CLI value means "the user didn't pass this flag", so
+       the TOML/default underneath shows through (AC-US-4.1).
+
+    Raises :class:`UsageError` (exit 2) when:
+    * ``input`` is missing — there is nothing to transcribe.
+    * ``lang`` is missing from both config and CLI (AC-US-4.3).
+    * any whitelisted field carries a value outside its allowed set
+      (AC-US-4.4 + the AC-US-1.5 did-you-mean for ``lang``).
+    """
+    cli_set = {k: v for k, v in cli_overrides.items() if v is not None}
+    merged: dict[str, Any] = {**_BUILTIN_DEFAULTS, **toml_defaults, **cli_set}
+
+    if "input" not in merged:
+        raise UsageError("INPUT path is required")
+    if "lang" not in merged:
+        raise _missing_lang_error()
+
+    merged["input"] = Path(merged["input"])
+    if merged["output"] is not None:
+        merged["output"] = Path(merged["output"])
+
+    try:
+        cfg = Config(**merged)
+    except TypeError as exc:
+        # Unknown TOML key: dataclass rejects it — translate to UsageError
+        # so the user sees an actionable message, not a TypeError trace.
+        raise UsageError(f"unrecognized config field: {exc}") from exc
+
+    validate(cfg)
+    return cfg
+
+
+def validate(cfg: Config) -> None:
+    """Validate every whitelisted field on ``cfg``; raise on any miss.
+
+    ``lang`` uses the same did-you-mean machinery as :mod:`.cli` so a
+    config-loaded typo (AC-US-4.4) gets the same hint as a CLI typo
+    (AC-US-1.5). The other three whitelists raise plain messages —
+    they're rare enough that did-you-mean noise isn't worth the LoC.
+    """
+    if cfg.lang not in SUPPORTED_LANGS:
+        supported = ", ".join(SUPPORTED_LANGS)
+        suggestion = _closest_supported_lang(cfg.lang)
+        base = f"unknown lang {cfg.lang!r}; supported: {supported}"
+        if suggestion is not None:
+            raise UsageError(f"{base}; did you mean `{suggestion}`?")
+        raise UsageError(base)
+
+    if cfg.model not in SUPPORTED_MODELS:
+        raise UsageError(f"unknown model {cfg.model!r}; supported: {', '.join(SUPPORTED_MODELS)}")
+
+    if cfg.backend not in SUPPORTED_BACKENDS:
+        raise UsageError(
+            f"unknown backend {cfg.backend!r}; supported: {', '.join(SUPPORTED_BACKENDS)}"
+        )
+
+    if cfg.device not in SUPPORTED_DEVICES:
+        raise UsageError(
+            f"unknown device {cfg.device!r}; supported: {', '.join(SUPPORTED_DEVICES)}"
+        )
+
+    if cfg.verbosity not in get_args(Verbosity):
+        raise UsageError(
+            f"unknown verbosity {cfg.verbosity!r}; supported: {', '.join(get_args(Verbosity))}"
+        )
+
+
+def _missing_lang_error() -> UsageError:
+    supported = ", ".join(SUPPORTED_LANGS)
+    return UsageError(f"--lang is required (e.g. --lang es). Supported: {supported}")
+
+
+def _closest_supported_lang(code: str) -> str | None:
+    """Return the closest supported code within ≤ 2 edits, or ``None``.
+
+    Ties break by :data:`SUPPORTED_LANGS` order so the suggestion is
+    deterministic across runs (e.g. ``es`` wins over ``en`` if both are
+    equidistant). Mirrors the cli helper of the same name; the
+    duplication is small enough not to warrant a shared helper module
+    until a third caller appears.
+    """
+    best: tuple[int, str] | None = None
+    for candidate in SUPPORTED_LANGS:
+        distance = _levenshtein(code, candidate)
+        if distance > _DID_YOU_MEAN_MAX_DISTANCE:
+            continue
+        if best is None or distance < best[0]:
+            best = (distance, candidate)
+    return best[1] if best is not None else None
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Standard edit distance; ADR-0013 forbids new runtime deps so we
+    inline rather than pulling in ``rapidfuzz``. Cost is negligible on
+    2-to-~8-character codes."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i]
+        for j, cb in enumerate(b, start=1):
+            insert = current[j - 1] + 1
+            delete = previous[j] + 1
+            substitute = previous[j - 1] + (ca != cb)
+            current.append(min(insert, delete, substitute))
+        previous = current
+    return previous[-1]
+
+
+__all__ = [
+    "DEFAULT_CONFIG_PATH",
+    "SUPPORTED_BACKENDS",
+    "SUPPORTED_DEVICES",
+    "SUPPORTED_LANGS",
+    "SUPPORTED_MODELS",
+    "Config",
+    "load_toml_defaults",
+    "merge",
+    "validate",
+]

--- a/src/podcast_script/config.py
+++ b/src/podcast_script/config.py
@@ -1,0 +1,6 @@
+"""C-Config: TOML defaults + CLI merge → ``Config`` dataclass (POD-016).
+
+Skeleton only — implementation lands in the TDD green steps.
+"""
+
+from __future__ import annotations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,9 +19,7 @@ from podcast_script.errors import UsageError
 
 
 @pytest.fixture(autouse=True)
-def _isolated_default_config_path(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def _isolated_default_config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Pin :data:`config.DEFAULT_CONFIG_PATH` to a non-existent path.
 
     Without this fixture every CLI test would pick up whatever
@@ -31,9 +29,7 @@ def _isolated_default_config_path(
     (the "no config + no --lang" path). Tests that *want* a config can
     override this fixture by monkeypatching the same attribute again.
     """
-    monkeypatch.setattr(
-        config_module, "DEFAULT_CONFIG_PATH", tmp_path / "no-such-config.toml"
-    )
+    monkeypatch.setattr(config_module, "DEFAULT_CONFIG_PATH", tmp_path / "no-such-config.toml")
 
 
 @pytest.fixture
@@ -612,14 +608,10 @@ class TestCliConfigMerge:
         monkeypatch.setattr(config_module, "DEFAULT_CONFIG_PATH", config_path)
 
         seen: dict[str, object] = {}
-        monkeypatch.setattr(
-            cli_module, "_run_pipeline", lambda **kw: seen.update(kw)
-        )
+        monkeypatch.setattr(cli_module, "_run_pipeline", lambda **kw: seen.update(kw))
 
         input_file = _touch(tmp_path, "episode.mp3")
-        result = runner.invoke(
-            app, [str(input_file), "--lang", "en", "--model", "tiny"]
-        )
+        result = runner.invoke(app, [str(input_file), "--lang", "en", "--model", "tiny"])
 
         assert result.exit_code == 0, f"stderr={result.stderr!r}"
         assert seen.get("lang") == "en"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,8 @@
 
 Covers the CLI surface that POD-006 owns: ``--lang`` curated-set validation
 (AC-US-1.5), required-``--lang`` rejection (AC-US-4.3), the typer entrypoint,
-and ADR-0006 exception → ``typer.Exit`` translation.
+and ADR-0006 exception → ``typer.Exit`` translation. POD-016 adds the
+config-merge surface (AC-US-4.1, AC-US-4.2, AC-US-4.4) at the CLI level.
 """
 
 from __future__ import annotations
@@ -12,8 +13,27 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+from podcast_script import config as config_module
 from podcast_script.cli import SUPPORTED_LANGS, app, validate_lang
 from podcast_script.errors import UsageError
+
+
+@pytest.fixture(autouse=True)
+def _isolated_default_config_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin :data:`config.DEFAULT_CONFIG_PATH` to a non-existent path.
+
+    Without this fixture every CLI test would pick up whatever
+    ``~/.config/podcast-script/config.toml`` happens to exist on the
+    machine running the suite — so a developer with a personal config
+    setting ``lang = "es"`` would silently mask AC-US-4.3 failures
+    (the "no config + no --lang" path). Tests that *want* a config can
+    override this fixture by monkeypatching the same attribute again.
+    """
+    monkeypatch.setattr(
+        config_module, "DEFAULT_CONFIG_PATH", tmp_path / "no-such-config.toml"
+    )
 
 
 @pytest.fixture
@@ -533,3 +553,94 @@ class TestForceOverwrite:
         # ADR-0005 §Consequences: no ``*.md.tmp`` debris left behind.
         leftover = list(tmp_path.glob("*.md.tmp"))
         assert leftover == [], f"unexpected temp leftovers: {leftover!r}"
+
+
+class TestCliConfigMerge:
+    """POD-016 — US-4 acceptance criteria at the CLI surface.
+
+    AC-US-4.3 already lives in :class:`TestCliMissingLang`. The three
+    here cover the config-aware paths: TOML supplies a missing flag,
+    CLI overrides TOML, and a TOML-loaded ``lang = "ja"`` is rejected
+    just like a CLI ``--lang ja`` would be.
+    """
+
+    def _write_config(self, path: Path, body: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    def test_toml_lang_used_when_cli_omits_it_AC_US_4_1(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # AC-US-4.1: with config.toml(lang="es") and no --lang flag,
+        # the run proceeds with lang=es. The pipeline is stubbed so the
+        # test isolates the merge path from segmenter/backend startup.
+        from podcast_script import cli as cli_module
+
+        config_path = tmp_path / "config.toml"
+        self._write_config(config_path, 'lang = "es"\nmodel = "large-v3"\n')
+        monkeypatch.setattr(config_module, "DEFAULT_CONFIG_PATH", config_path)
+
+        seen: dict[str, object] = {}
+
+        def fake_run_pipeline(**kwargs: object) -> None:
+            seen.update(kwargs)
+
+        monkeypatch.setattr(cli_module, "_run_pipeline", fake_run_pipeline)
+
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(app, [str(input_file)])
+
+        assert result.exit_code == 0, f"stderr={result.stderr!r}"
+        assert seen.get("lang") == "es"
+        assert seen.get("model") == "large-v3"
+
+    def test_cli_flags_override_toml_AC_US_4_2(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # AC-US-4.2: same config(lang="es", model="large-v3"), CLI
+        # passes --lang en --model tiny → CLI wins on both fields.
+        from podcast_script import cli as cli_module
+
+        config_path = tmp_path / "config.toml"
+        self._write_config(config_path, 'lang = "es"\nmodel = "large-v3"\n')
+        monkeypatch.setattr(config_module, "DEFAULT_CONFIG_PATH", config_path)
+
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            cli_module, "_run_pipeline", lambda **kw: seen.update(kw)
+        )
+
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(
+            app, [str(input_file), "--lang", "en", "--model", "tiny"]
+        )
+
+        assert result.exit_code == 0, f"stderr={result.stderr!r}"
+        assert seen.get("lang") == "en"
+        assert seen.get("model") == "tiny"
+
+    def test_unsupported_toml_lang_rejected_AC_US_4_4(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # AC-US-4.4: config.toml(lang="ja") + no --lang → exit 2,
+        # same AC-US-1.5 validation as a CLI --lang ja would trigger.
+        config_path = tmp_path / "config.toml"
+        self._write_config(config_path, 'lang = "ja"\n')
+        monkeypatch.setattr(config_module, "DEFAULT_CONFIG_PATH", config_path)
+
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(app, [str(input_file)])
+
+        assert result.exit_code == 2, f"stderr={result.stderr!r}"
+        # Same logfmt token as any other usage error (ADR-0006 + ADR-0008).
+        assert "event=usage_error" in result.stderr
+        assert "ja" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -636,3 +636,9 @@ class TestCliConfigMerge:
         # Same logfmt token as any other usage error (ADR-0006 + ADR-0008).
         assert "event=usage_error" in result.stderr
         assert "ja" in result.stderr
+        # AC-US-4.4 says the same validation as AC-US-1.5 fires, which
+        # includes the did-you-mean hint when within edit-distance 2.
+        # ``ja`` is distance 1 from ``ca`` (j→c) — pin the suggestion so
+        # a future refactor that bypasses ``validate_lang`` for the TOML
+        # path can't pass this test silently.
+        assert "did you mean `ca`" in result.stderr

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,6 +91,26 @@ def test_merge_raises_when_lang_is_unset_anywhere(tmp_path: Path) -> None:
         assert code in msg
 
 
+def test_merge_expands_tilde_in_toml_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ADR-0013 §Decision step 5 — ``Path(str).expanduser().resolve()``.
+
+    A TOML ``output = "~/episodes/ep.md"`` must reach the pipeline as
+    ``<HOME>/episodes/ep.md`` already absolute, otherwise downstream
+    code (``_check_output_path``, atomic-write) sees a literal ``~``
+    in the path and the run fails for the wrong reason.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "episodes").mkdir()
+
+    toml_defaults = {"lang": "es", "output": "~/episodes/ep.md"}
+    cli_overrides = {"input": "~/in.mp3", "lang": None}
+
+    cfg = config.merge(toml_defaults=toml_defaults, cli_overrides=cli_overrides)
+
+    assert cfg.input == (tmp_path / "in.mp3").resolve()
+    assert cfg.output == (tmp_path / "episodes" / "ep.md").resolve()
+
+
 def test_merge_rejects_unsupported_lang_from_toml(tmp_path: Path) -> None:
     """AC-US-4.4 — config-loaded ``lang = "ja"`` triggers the same
     AC-US-1.5 validation as a CLI ``--lang ja`` would (exit 2).

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,105 @@
+"""Tests for ``config.py`` (POD-016 — US-4 / ADR-0013).
+
+The four acceptance criteria split cleanly across the public API of
+``config``:
+
+* AC-US-4.1 — TOML defaults flow into ``Config`` when CLI omits the
+  flag (covered by ``test_toml_defaults_provide_lang_when_cli_omits``).
+* AC-US-4.2 — CLI wins on conflict (covered by
+  ``test_cli_overrides_win_over_toml_defaults``).
+* AC-US-4.3 — no config + no ``--lang`` → ``UsageError`` exit 2
+  (covered by ``test_merge_raises_when_lang_is_unset_anywhere``).
+* AC-US-4.4 — config-loaded lang revalidates the same as a CLI lang
+  (covered by ``test_merge_rejects_unsupported_lang_from_toml``).
+
+Tests target the merge-level public surface (``load_toml_defaults`` and
+``merge``) so the tests survive the dataclass shape evolving — only
+behavior the SRS commits to is asserted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from podcast_script import config
+from podcast_script.errors import UsageError
+
+
+def test_load_toml_defaults_returns_empty_dict_for_missing_path(tmp_path: Path) -> None:
+    """A missing config file is the *normal* case — running with no
+    config and a complete CLI must not error. ADR-0013 sketch returns
+    an empty dict; we lock that contract here so callers can blindly
+    spread the result into ``merge``.
+    """
+    missing = tmp_path / "config.toml"
+    assert not missing.exists()
+
+    assert config.load_toml_defaults(missing) == {}
+
+
+def test_load_toml_defaults_parses_supported_keys(tmp_path: Path) -> None:
+    """Smoke that ``tomllib`` is wired at all and that the keys we
+    expect to see (``lang`` + ``model``) come back as plain ``str``.
+    """
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text('lang = "es"\nmodel = "large-v3"\n', encoding="utf-8")
+
+    assert config.load_toml_defaults(cfg_path) == {"lang": "es", "model": "large-v3"}
+
+
+def test_toml_defaults_provide_lang_when_cli_omits(tmp_path: Path) -> None:
+    """AC-US-4.1 — running with no ``--lang`` falls back to the TOML
+    ``lang``; the run proceeds without error.
+    """
+    toml_defaults = {"lang": "es", "model": "large-v3"}
+    cli_overrides = {"input": tmp_path / "ep.mp3", "lang": None, "model": None}
+
+    cfg = config.merge(toml_defaults=toml_defaults, cli_overrides=cli_overrides)
+
+    assert cfg.lang == "es"
+    assert cfg.model == "large-v3"
+
+
+def test_cli_overrides_win_over_toml_defaults(tmp_path: Path) -> None:
+    """AC-US-4.2 — CLI ``--lang en --model tiny`` beats the same fields
+    in TOML.
+    """
+    toml_defaults = {"lang": "es", "model": "large-v3"}
+    cli_overrides = {"input": tmp_path / "ep.mp3", "lang": "en", "model": "tiny"}
+
+    cfg = config.merge(toml_defaults=toml_defaults, cli_overrides=cli_overrides)
+
+    assert cfg.lang == "en"
+    assert cfg.model == "tiny"
+
+
+def test_merge_raises_when_lang_is_unset_anywhere(tmp_path: Path) -> None:
+    """AC-US-4.3 — no config and no ``--lang`` exits 2; the message
+    must list the eight supported codes so the user can self-correct.
+    """
+    cli_overrides = {"input": tmp_path / "ep.mp3", "lang": None}
+
+    with pytest.raises(UsageError) as excinfo:
+        config.merge(toml_defaults={}, cli_overrides=cli_overrides)
+
+    assert excinfo.value.exit_code == 2
+    msg = str(excinfo.value)
+    # The eight v1 codes from SRS §1.7 — every one must appear.
+    for code in ("es", "en", "pt", "fr", "de", "it", "ca", "eu"):
+        assert code in msg
+
+
+def test_merge_rejects_unsupported_lang_from_toml(tmp_path: Path) -> None:
+    """AC-US-4.4 — config-loaded ``lang = "ja"`` triggers the same
+    AC-US-1.5 validation as a CLI ``--lang ja`` would (exit 2).
+    """
+    toml_defaults = {"lang": "ja"}
+    cli_overrides = {"input": tmp_path / "ep.mp3", "lang": None}
+
+    with pytest.raises(UsageError) as excinfo:
+        config.merge(toml_defaults=toml_defaults, cli_overrides=cli_overrides)
+
+    assert excinfo.value.exit_code == 2
+    assert "ja" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Add `config.py` (C-Config): stdlib `tomllib` loader, frozen+slots `Config` dataclass, CLI-wins `merge`, and `validate` per ADR-0013.
- Wire `config.merge` into the CLI; CLI flags pass `None` for "unset" so TOML / built-in defaults show through (AC-US-4.1).
- Closes POD-016 under US-4, sprint SP-4.

## Acceptance criteria satisfied
- [x] AC-US-4.1 — `tests/test_cli.py::TestCliConfigMerge::test_toml_lang_used_when_cli_omits_it_AC_US_4_1` + `tests/test_config.py::test_toml_defaults_provide_lang_when_cli_omits`
- [x] AC-US-4.2 — `tests/test_cli.py::TestCliConfigMerge::test_cli_flags_override_toml_AC_US_4_2` + `tests/test_config.py::test_cli_overrides_win_over_toml_defaults`
- [x] AC-US-4.3 — `tests/test_cli.py::TestCliMissingLang` (now hermetic via autouse `_isolated_default_config_path` fixture) + `tests/test_config.py::test_merge_raises_when_lang_is_unset_anywhere`
- [x] AC-US-4.4 — `tests/test_cli.py::TestCliConfigMerge::test_unsupported_toml_lang_rejected_AC_US_4_4` + `tests/test_config.py::test_merge_rejects_unsupported_lang_from_toml`

## Design notes
- Defaults moved out of the typer signature into `config._BUILTIN_DEFAULTS` so a TOML value can show through whenever the user didn't type the flag. ``--model`` and ``--device`` defaults are now documented in their ``help=`` strings instead of typer's auto-rendered ``[default: ...]``.
- `force` and `verbosity` remain CLI-driven (typer can't represent "unset" for `bool`); per SRS §1.3 these are not advertised as TOML-overridable, and a TOML-default `force=true` would be a safety footgun against AC-US-6.x.
- `validate_lang(code)` extracted from `validate(cfg)` so the CLI's standalone lang validator and the config-loaded path produce identical error shapes (AC-US-1.5 ≡ AC-US-4.4). `cli.py` re-exports it (and `SUPPORTED_LANGS`) for backward compatibility.
- Autouse fixture in `test_cli.py` pins `config.DEFAULT_CONFIG_PATH` to a non-existent tmp path; without it any developer with a real `~/.config/podcast-script/config.toml` would silently mask AC-US-4.3 in their local run.

## Risks touched
- None new. ADR-0013 ("zero new runtime deps") respected — only stdlib `tomllib` + `dataclasses`.

## Documentation updated
- n/a — README (POD-036 / SP-7) and CHANGELOG (POD-038 / SP-8) don't exist yet; no new ADR needed (ADR-0013 already covers).

## Test plan
- [x] `uv run pytest -q` — 196 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy --strict src tests` — clean
- [ ] Reviewer to verify CLI behaviour by writing a `~/.config/podcast-script/config.toml` (`lang = "es"`) and running ``podcast-script <input>`` without ``--lang``.

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target.
- [x] Tests green on detected toolchain locally.
- [ ] CI matrix (Ubuntu + macOS-14) green — surfaces on push.
- [ ] Stakeholder signoff at sprint review (post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)