### PR TITLE
chore: tighten pytest warnings policy + suppress upstream noise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,12 @@ addopts = ["-ra", "--strict-markers", "--strict-config", "-m", "not slow"]
 # the grep contract. Production audio routinely has silent intros /
 # outros, which trigger inaSpeechSegmenter's z-score normalisation on
 # near-zero-variance frames, so the suppression has to be airtight.
-# Whitelisted entries below are upstream issues we cannot fix without
-# bumping the segmenter — tracked under SPK-1 in PROJECT_PLAN §10.1.
+#
+# No whitelist needed at the pytest layer: known-benign upstream noise
+# (the SciPy DeprecationWarning + the numpy invalid-value
+# RuntimeWarnings — SPK-1 fragility, PROJECT_PLAN §10.1 R-1) is silenced
+# at the runtime boundary in `src/podcast_script/segment.py`. Adding
+# entries here would mask a future regression in our own code.
 filterwarnings = ["error"]
 markers = [
     # Tier 3 integration tests on the real examples/sample.mp3 fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,15 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["-ra", "--strict-markers", "--strict-config", "-m", "not slow"]
+# Warnings policy — NFR-10 (logfmt key=value on stderr only). Anything
+# that escapes the runtime suppression in `InaSpeechSegmenter` is a real
+# regression: it leaks Python warnings into the user's pipe and breaks
+# the grep contract. Production audio routinely has silent intros /
+# outros, which trigger inaSpeechSegmenter's z-score normalisation on
+# near-zero-variance frames, so the suppression has to be airtight.
+# Whitelisted entries below are upstream issues we cannot fix without
+# bumping the segmenter — tracked under SPK-1 in PROJECT_PLAN §10.1.
+filterwarnings = ["error"]
 markers = [
     # Tier 3 integration tests on the real examples/sample.mp3 fixture
     # (POD-031). Skipped by default — opt in with `pytest -m slow` or

--- a/src/podcast_script/backends/base.py
+++ b/src/podcast_script/backends/base.py
@@ -21,6 +21,7 @@ emit-once logic here keeps faster + mlx mirrors free of duplication.
 from __future__ import annotations
 
 import logging
+import os
 import platform
 import sys
 from collections.abc import Callable, Iterable
@@ -30,6 +31,18 @@ import numpy as np
 import numpy.typing as npt
 
 from ..errors import UsageError
+
+# NFR-10 compatibility — silence ``huggingface_hub`` WARNING-level logs.
+# On a cold cache (first ever run, fresh CI runner, post-cache-clear)
+# the lib's HTTP layer emits ``Warning: You are sending unauthenticated
+# requests to the HF Hub. Please set a HF_TOKEN ...`` directly on
+# stderr via Python's :mod:`logging`, breaking the logfmt-only promise.
+# We don't authenticate (the project is public-domain audio + open
+# Whisper weights, no token model exists in our scope), and the warning
+# is purely informational. ``HF_HUB_VERBOSITY=error`` is the documented
+# control for the lib's log level. ``setdefault`` lets a developer who
+# *does* want HF debug output override us by exporting the variable.
+os.environ.setdefault("HF_HUB_VERBOSITY", "error")
 
 
 class TranscribedSegment(NamedTuple):

--- a/src/podcast_script/segment.py
+++ b/src/podcast_script/segment.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextlib
 import os
 import tempfile
+import warnings
 import wave
 from dataclasses import dataclass
 from pathlib import Path
@@ -227,7 +228,19 @@ class InaSpeechSegmenter:
         os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
         _patch_pyannote_viterbi_for_modern_numpy()
 
-        from inaSpeechSegmenter import Segmenter as _InaSeg  # type: ignore[import-untyped]
+        # Silence the SciPy DeprecationWarning fired at import time —
+        # ``inaSpeechSegmenter/sidekit_mfcc.py`` imports ``dct`` from a
+        # path that's slated for removal in SciPy 2.0. Upstream issue;
+        # disappears the day the segmenter bumps. Captured here (not at
+        # module load) so a real DeprecationWarning from our own code
+        # would still surface in tests via the pytest ``error`` filter.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                module=r"inaSpeechSegmenter\..*",
+            )
+            from inaSpeechSegmenter import Segmenter as _InaSeg  # type: ignore[import-untyped]
 
         return _InaSeg(vad_engine="smn", detect_gender=False)
 
@@ -244,9 +257,31 @@ class InaSpeechSegmenter:
         v0.7.6) and invokes the engine on its path. The temp WAV is
         deleted on context exit so a long-running process never
         accumulates fixture-sized scratch files.
+
+        Production audio routinely contains silent intros / outros and
+        ad breaks. inaSpeechSegmenter z-score-normalises feature
+        windows by ``(x - mean) / std``; on a near-zero-variance frame
+        ``std`` is ~0 and the resulting NaN propagates, firing two
+        ``RuntimeWarning("invalid value encountered in subtract")``
+        warnings (one in ``segmenter.py:62``, one inside
+        ``numpy/_methods.py``). The downstream code handles the NaN
+        fine — segmentation labels still come out correctly — so the
+        warnings are pure user-visible noise that breaks NFR-10's
+        clean-stderr promise. We suppress them at this single boundary
+        rather than at module load so we don't accidentally hide a
+        warning from our own code.
         """
         real_engine = cast("_InaEngine", engine)
-        with self._pcm_to_temp_wav(pcm) as wav_path:
+        with (
+            self._pcm_to_temp_wav(pcm) as wav_path,
+            np.errstate(invalid="ignore", divide="ignore"),
+            warnings.catch_warnings(),
+        ):
+            warnings.filterwarnings(
+                "ignore",
+                category=RuntimeWarning,
+                message="invalid value encountered in subtract",
+            )
             result = real_engine(str(wav_path))
         return [(label, float(start), float(end)) for label, start, end in result]
 

--- a/tests/test_integration_tiny.py
+++ b/tests/test_integration_tiny.py
@@ -128,6 +128,18 @@ def test_cli_tiny_pipeline_produces_structural_markdown(
         f"missing terminal write_done event; stderr={result.stderr!r}"
     )
 
+    # NFR-10 — stderr is logfmt key=value pairs *only*. Stray Python
+    # warnings (DeprecationWarning, RuntimeWarning, …) leaking to the
+    # user's pipe break that contract. The runtime suppression in
+    # ``InaSpeechSegmenter`` must keep upstream lib noise contained
+    # even on production audio, where silent intros / outros routinely
+    # trigger inaSpeechSegmenter's z-score normalisation on
+    # near-zero-variance frames.
+    for noise in ("Warning:", "DeprecationWarning", "RuntimeWarning"):
+        assert noise not in result.stderr, (
+            f"{noise!r} leaked to stderr; stderr={result.stderr!r}"
+        )
+
     body = output_path.read_text(encoding="utf-8")
     _assert_structural_invariants(body)
 

--- a/tests/test_integration_tiny.py
+++ b/tests/test_integration_tiny.py
@@ -136,9 +136,7 @@ def test_cli_tiny_pipeline_produces_structural_markdown(
     # trigger inaSpeechSegmenter's z-score normalisation on
     # near-zero-variance frames.
     for noise in ("Warning:", "DeprecationWarning", "RuntimeWarning"):
-        assert noise not in result.stderr, (
-            f"{noise!r} leaked to stderr; stderr={result.stderr!r}"
-        )
+        assert noise not in result.stderr, f"{noise!r} leaked to stderr; stderr={result.stderr!r}"
 
     body = output_path.read_text(encoding="utf-8")
     _assert_structural_invariants(body)


### PR DESCRIPTION
## Summary

Closes a real production gap surfaced while testing on real audio: `inaSpeechSegmenter` was leaking upstream Python warnings to user stderr on every CLI run, breaking NFR-10's "logfmt key=value only" promise. Tightens pytest to fail on any unhandled warning so the next leak can't slide past silently.

Tactical follow-up; no new POD-NNN booked. The dep-stack fragility this addresses is the same SPK-1 risk PROJECT_PLAN §10.1 R-1 already flagged.

## Production motivation

Real podcasts routinely have:
- Silent intros / outros / ad breaks
- Variable-volume segments

These trigger `inaSpeechSegmenter`'s z-score normalisation on near-zero-variance feature frames, producing NaN and firing two `RuntimeWarning("invalid value encountered in subtract")` lines per run on stderr. Plus a `DeprecationWarning` from a SciPy import path slated for removal in SciPy 2.0. None affect segmentation accuracy — pure user-visible noise.

## What changed

### Pytest policy (`pyproject.toml`)
```toml
filterwarnings = ["error"]
```
Any unhandled Python warning now fails the test. The next upstream surprise can't slide past silently.

### Runtime suppression (`src/podcast_script/segment.py`)
Two narrow boundaries touch the lib:
- **`_build_engine`** — wraps the lazy `from inaSpeechSegmenter import Segmenter` in `warnings.catch_warnings()` + `filterwarnings("ignore", category=DeprecationWarning, module="inaSpeechSegmenter\\..*")`.
- **`_run_engine`** — wraps the engine call in `np.errstate(invalid="ignore", divide="ignore")` + `warnings.filterwarnings("ignore", category=RuntimeWarning, message="invalid value encountered in subtract")`.

Confined to these two boundaries (not module-load) so warnings from *our* code still surface via the strict pytest filter.

### Tier-3 integration test (`tests/test_integration_tiny.py`)
New assertion locks down the production stderr promise:
```python
for noise in ("Warning:", "DeprecationWarning", "RuntimeWarning"):
    assert noise not in result.stderr
```
Survives even if the pytest policy is later loosened.

## Known limitation (not in this PR)

Two C-level stderr lines still leak — they bypass Python's `warnings` module entirely (raw `fwrite` from C extensions):

- `[ctranslate2] ... [warning] The compute type inferred from the saved model is float16, but the target device or backend do not support efficient float16 computation.` — from faster-whisper's underlying inference engine.
- `93/93 - 1s - 675ms/epoch - 7ms/step` — Keras `model.predict(verbose=1)` progress bar, hard-coded inside `inaSpeechSegmenter`'s feature-extraction call.

Both need OS-level fd redirection (`os.dup2` swap of fd 2) to suppress. Invasive enough to deserve its own PR; flagging here so it isn't lost.

## Test plan

- [x] `uv run pytest -m "slow or not slow"` — 206 passed in ~10 s, **0 warnings**.
- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format --check .` — clean.
- [x] `uv run mypy --strict src tests` — clean.
- [x] Manual smoke: `uv run podcast-script examples/sample.mp3 --lang es --model tiny --backend faster-whisper -o /tmp/out.md` — confirmed `RuntimeWarning` and `DeprecationWarning` no longer appear on stderr; only the two known C-level lines remain.
- [ ] CI matrix (Ubuntu + macOS-14) — surfaces on push.

## Definition of Done

- [x] Trunk-based feature branch, squash-merge target.
- [x] Tests green on detected toolchain locally.
- [ ] CI matrix green (surfaces on push).
- [ ] Stakeholder signoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)