### PR TITLE
feat(POD-013): rich progress bar with three named tasks (US-3 / ADR-0010)

### DIFF
--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -43,6 +43,7 @@ from .config import SUPPORTED_LANGS, validate_lang
 from .errors import InputIOError, OutputExistsError, PodcastScriptError
 from .logging_setup import configure
 from .pipeline import RunSummary
+from .progress import Progress, make_progress
 
 if TYPE_CHECKING:
     from .backends.base import WhisperBackend
@@ -147,6 +148,7 @@ def _run_pipeline(
     model: str,
     backend_instance: WhisperBackend,
     device: str,
+    progress: Progress,
     force: bool,
     debug: bool,
 ) -> RunSummary:
@@ -154,14 +156,14 @@ def _run_pipeline(
 
     The cli is the composition root (ADR-0002 §Decision step 4) — it
     instantiates the concrete stages and hands them to :class:`Pipeline`.
-    The ``backend_instance`` is resolved by ``main()`` via
-    :func:`~podcast_script.backends.base.select_backend` so the
-    ``event=backend_selected`` lifecycle event (ADR-0012) can fire
-    *before* this function is called — that way the line surfaces even
-    when tests stub ``_run_pipeline`` to a no-op. ``--force`` /
-    ``--debug`` wiring is plumbed but their pipeline-level effects
-    (atomic-rename invariant; debug-artifact dir) live in POD-009 /
-    POD-024 — the cli just hands them through.
+    Both ``backend_instance`` (via ``select_backend``) and ``progress``
+    (via :func:`~podcast_script.progress.make_progress`) are resolved
+    by ``main()`` so their lifecycle events (``backend_selected``) and
+    log-handler-Console binding (ADR-0008) can be set up before the
+    pipeline runs. ``--force`` / ``--debug`` wiring is plumbed but
+    their pipeline-level effects (atomic-rename invariant;
+    debug-artifact dir) live in POD-009 / POD-024 — the cli just hands
+    them through.
     """
     del force, debug
 
@@ -178,6 +180,7 @@ def _run_pipeline(
         model=model,
         device=device,
         lang=lang,
+        progress=progress,
     )
     return pipeline.run(input_path=input_path, output_path=output_path)
 
@@ -297,16 +300,29 @@ def main(
 
         resolved_output = cfg.output if cfg.output is not None else cfg.input.with_suffix(".md")
         _check_output_path(resolved_output, force=cfg.force)
-        summary = _run_pipeline(
-            input_path=cfg.input,
-            output_path=resolved_output,
-            lang=cfg.lang,
-            model=cfg.model,
-            backend_instance=backend_instance,
-            device=cfg.device,
-            force=cfg.force,
-            debug=debug,
-        )
+
+        # POD-013 — three-phase progress bar (decode / segment /
+        # transcribe). Hoisted up here (not inside ``_run_pipeline``)
+        # so we can re-configure the log handler to share the Progress
+        # console per ADR-0008 — keeps progress + log lines from
+        # tearing on a real TTY. ``make_progress`` honours AC-US-3.2
+        # by disabling itself on non-TTY stderr so pipe / CI captures
+        # see no ANSI. The ``with`` block guarantees ``Progress.stop()``
+        # even if the pipeline raises.
+        bar = make_progress()
+        log = configure(verbosity, progress=bar)
+        with bar:
+            summary = _run_pipeline(
+                input_path=cfg.input,
+                output_path=resolved_output,
+                lang=cfg.lang,
+                model=cfg.model,
+                backend_instance=backend_instance,
+                device=cfg.device,
+                progress=bar,
+                force=cfg.force,
+                debug=debug,
+            )
 
         # SRS UC-1 step 10 — locked logfmt summary line.
         # Shape: ``level=info event=done input=<path> output=<path>

--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -29,6 +29,7 @@ the heavy ML deps.
 
 from __future__ import annotations
 
+import contextlib
 import platform
 import sys
 import time
@@ -148,7 +149,7 @@ def _run_pipeline(
     model: str,
     backend_instance: WhisperBackend,
     device: str,
-    progress: Progress,
+    progress: Progress | None,
     force: bool,
     debug: bool,
 ) -> RunSummary:
@@ -307,11 +308,17 @@ def main(
         # console per ADR-0008 — keeps progress + log lines from
         # tearing on a real TTY. ``make_progress`` honours AC-US-3.2
         # by disabling itself on non-TTY stderr so pipe / CI captures
-        # see no ANSI. The ``with`` block guarantees ``Progress.stop()``
-        # even if the pipeline raises.
-        bar = make_progress()
+        # see no ANSI.
+        #
+        # ``--quiet`` constructs no Progress at all per ADR-0008
+        # §Decision step 4 / AC-US-3.3 — POD-014 will lift this gate
+        # once the full verbosity matrix lands. The ``with`` block
+        # guarantees ``Progress.stop()`` even if the pipeline raises;
+        # ``nullcontext()`` keeps the call shape symmetric on the
+        # ``--quiet`` path.
+        bar = make_progress() if verbosity != "quiet" else None
         log = configure(verbosity, progress=bar)
-        with bar:
+        with bar if bar is not None else contextlib.nullcontext():
             summary = _run_pipeline(
                 input_path=cfg.input,
                 output_path=resolved_output,

--- a/src/podcast_script/pipeline.py
+++ b/src/podcast_script/pipeline.py
@@ -32,6 +32,7 @@ import numpy.typing as npt
 
 from .atomic_write import atomic_write
 from .backends.base import TranscribedSegment, WhisperBackend
+from .progress import DECODE_TASK, SEGMENT_TASK, TRANSCRIBE_TASK, Progress
 from .render import RenderFn, TimestampFormat
 from .segment import Segment, Segmenter
 
@@ -80,6 +81,11 @@ class Pipeline:
     device: str
     lang: str
     sample_rate: int = 16_000
+    # POD-013 — optional progress bar. When ``None`` the pipeline runs
+    # silently (Tier 1 unit-test path); when present, the cli composition
+    # root has wired :func:`podcast_script.progress.make_progress` and the
+    # phase methods tick it per ADR-0010.
+    progress: Progress | None = None
 
     def run(self, *, input_path: Path, output_path: Path) -> RunSummary:
         """Run the full pipeline; write Markdown atomically to ``output_path``.
@@ -141,6 +147,8 @@ class Pipeline:
                 "duration_in_s": f"{duration_s:.3f}",
             },
         )
+        if self.progress is not None:
+            self.progress.advance(DECODE_TASK, 1)
         return pcm
 
     def _choose_fmt(self, pcm: npt.NDArray[np.float32]) -> TimestampFormat:
@@ -155,6 +163,13 @@ class Pipeline:
             "",
             extra={"event": "segment_done", "n_segments": len(segments)},
         )
+        if self.progress is not None:
+            self.progress.advance(SEGMENT_TASK, 1)
+            # ADR-0010 — set the transcribe task's total now that we know
+            # how many speech segments will be processed; the bar's
+            # percentage becomes meaningful for the transcribe phase.
+            n_speech = sum(1 for s in segments if s.label == "speech")
+            self.progress.update(TRANSCRIBE_TASK, total=n_speech)
         return segments
 
     def _transcribe_speech(
@@ -186,6 +201,12 @@ class Pipeline:
                         text=ts.text,
                     )
                 )
+            # ADR-0010 — tick once per outer-loop iteration over speech
+            # segments. Backend-agnostic: faster-whisper yields incrementally
+            # while mlx-whisper may yield all results at once at the end of
+            # ``transcribe()``. The user sees the same UX on both.
+            if self.progress is not None:
+                self.progress.advance(TRANSCRIBE_TASK, 1)
         _log.info(
             "",
             extra={

--- a/src/podcast_script/progress.py
+++ b/src/podcast_script/progress.py
@@ -1,0 +1,98 @@
+"""C-Progress: rich progress bar for the three pipeline phases (POD-013).
+
+The pipeline (ADR-0002) ticks one task per phase:
+
+* ``decode`` — atomic; advanced once when ``ffmpeg`` returns the PCM.
+* ``segment`` — atomic; advanced once when the segmenter pass finishes.
+* ``transcribe`` — per ADR-0010, total = ``len(speech_segments)``;
+  advanced once per outer-loop iteration over speech segments. This
+  keeps the UX identical on Linux/CUDA, Linux/CPU, and Apple Silicon
+  (NFR-7) — neither backend's internal yield cadence is observable.
+
+ADR-0008 — the Console used here is shared with the log handler
+(:func:`podcast_script.logging_setup.configure`) so progress + log
+lines render on the same TTY without tearing.
+
+AC-US-3.2 — non-TTY stderr must not paint ANSI. Rich's ``Progress``
+already does the right thing when its target stream's ``.isatty()``
+returns ``False`` (``disable=True``), so the cli composition root just
+hands the real stderr in. Tests substitute a hermetic ``StringIO`` /
+fake-TTY to exercise both branches without depending on the runner's
+actual stderr state.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import IO
+
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+
+# Public task-id constants. Locked at 0/1/2 to match the registration
+# order in :func:`make_progress`. Callers should reach for these
+# instead of integer literals so a future refactor that re-orders the
+# tasks fails compilation rather than silently no-op'ing ticks.
+DECODE_TASK: TaskID = TaskID(0)
+SEGMENT_TASK: TaskID = TaskID(1)
+TRANSCRIBE_TASK: TaskID = TaskID(2)
+
+
+def make_progress(*, file: IO[str] | None = None) -> Progress:
+    """Build the three-phase progress bar.
+
+    ``file`` is the destination stream (``sys.stderr`` by default — the
+    cli passes it explicitly so tests can substitute a non-TTY stream
+    to exercise the AC-US-3.2 fallback). Rich's ``Console`` infers
+    ``no_color`` / ANSI behaviour from the stream's ``.isatty()``, and
+    we mirror that into ``Progress.disable`` so a piped stderr writes
+    nothing.
+
+    The returned ``Progress`` already has the three named tasks
+    registered; the pipeline calls
+    :meth:`~rich.progress.Progress.advance` against the locked task
+    IDs (:data:`DECODE_TASK` / :data:`SEGMENT_TASK` /
+    :data:`TRANSCRIBE_TASK`).
+    """
+    stream = file if file is not None else sys.stderr
+    is_tty = bool(getattr(stream, "isatty", lambda: False)())
+
+    console = Console(file=stream, force_terminal=is_tty)
+    bar = Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TimeElapsedColumn(),
+        console=console,
+        # ``disable`` short-circuits all rendering — the AC-US-3.2 path.
+        disable=not is_tty,
+        # ``transient=False`` keeps the final state visible after the
+        # run completes, so ``--debug`` captures or screencasts retain
+        # the "decode 100% / segment 100% / transcribe 100%" record.
+        transient=False,
+    )
+
+    # Decode + segment are atomic; transcribe's total is set by the
+    # pipeline once the segmenter pass returns ``len(speech_segments)``.
+    bar.add_task("decode", total=1)
+    bar.add_task("segment", total=1)
+    bar.add_task("transcribe", total=None)
+
+    return bar
+
+
+__all__ = [
+    "DECODE_TASK",
+    "SEGMENT_TASK",
+    "TRANSCRIBE_TASK",
+    "Progress",
+    "TaskID",
+    "make_progress",
+]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -380,3 +380,113 @@ def test_transcribed_segments_re_anchored_to_episode_time(tmp_path: Path) -> Non
     assert seen[0].start == pytest.approx(4.1)
     assert seen[0].end == pytest.approx(4.9)
     assert seen[0].text == "hola"
+
+
+# ---------------------------------------------------------------------------
+# POD-013 — progress bar wiring (ADR-0010 — pipeline-level, per-segment ticks)
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_advances_each_phase_task_once_POD_013(tmp_path: Path) -> None:
+    """ADR-0010 — decode + segment are atomic phases (one tick each);
+    transcribe ticks once per speech segment regardless of backend
+    yield cadence. We capture the advance() calls on a recording
+    Progress so we can assert the order + counts without rendering.
+    """
+    from podcast_script.progress import (
+        DECODE_TASK,
+        SEGMENT_TASK,
+        TRANSCRIBE_TASK,
+        make_progress,
+    )
+
+    input_path = tmp_path / "episode.mp3"
+    input_path.write_bytes(b"")
+    output_path = tmp_path / "episode.md"
+
+    # Three speech segments → transcribe should tick three times.
+    segments = [
+        Segment(0.0, 1.0, "speech"),
+        Segment(1.0, 2.0, "music"),
+        Segment(2.0, 3.0, "speech"),
+        Segment(3.0, 4.0, "speech"),
+    ]
+    pipeline, _backend, _segmenter = _make_pipeline(
+        pcm=_silence_pcm(4.0),
+        segments=segments,
+    )
+
+    bar = make_progress()
+    advances: list[tuple[int, float]] = []
+    real_advance = bar.advance
+
+    def recording_advance(task_id: object, advance: float = 1.0) -> None:
+        advances.append((int(task_id), advance))  # type: ignore[arg-type]
+        real_advance(task_id, advance)  # type: ignore[arg-type]
+
+    bar.advance = recording_advance  # type: ignore[method-assign]
+    pipeline.progress = bar
+
+    pipeline.run(input_path=input_path, output_path=output_path)
+
+    decode_ticks = [a for a in advances if a[0] == DECODE_TASK]
+    segment_ticks = [a for a in advances if a[0] == SEGMENT_TASK]
+    transcribe_ticks = [a for a in advances if a[0] == TRANSCRIBE_TASK]
+
+    assert len(decode_ticks) == 1, advances
+    assert len(segment_ticks) == 1, advances
+    # Three speech segments out of four total — transcribe ticks 3 times.
+    assert len(transcribe_ticks) == 3, advances
+
+
+def test_pipeline_sets_transcribe_total_to_speech_segment_count_POD_013(
+    tmp_path: Path,
+) -> None:
+    """ADR-0010 — transcribe task total is set after the segmenter pass
+    so the bar's percentage is meaningful. Six segments, two of them
+    speech → transcribe.total == 2.
+    """
+    from podcast_script.progress import TRANSCRIBE_TASK, make_progress
+
+    input_path = tmp_path / "episode.mp3"
+    input_path.write_bytes(b"")
+    output_path = tmp_path / "episode.md"
+
+    segments = [
+        Segment(0.0, 1.0, "noise"),
+        Segment(1.0, 2.0, "speech"),
+        Segment(2.0, 3.0, "music"),
+        Segment(3.0, 4.0, "silence"),
+        Segment(4.0, 5.0, "speech"),
+        Segment(5.0, 6.0, "music"),
+    ]
+    pipeline, _backend, _segmenter = _make_pipeline(
+        pcm=_silence_pcm(6.0),
+        segments=segments,
+    )
+    bar = make_progress()
+    pipeline.progress = bar
+
+    pipeline.run(input_path=input_path, output_path=output_path)
+
+    assert bar.tasks[TRANSCRIBE_TASK].total == 2
+
+
+def test_pipeline_works_without_progress_bar_POD_013(tmp_path: Path) -> None:
+    """``Pipeline.progress = None`` is the default — Tier 1 unit tests
+    that don't pass a Progress must keep working unchanged. This
+    guards against a regression where the orchestrator unconditionally
+    dereferences the field.
+    """
+    input_path = tmp_path / "episode.mp3"
+    input_path.write_bytes(b"")
+    output_path = tmp_path / "episode.md"
+
+    pipeline, _backend, _segmenter = _make_pipeline(
+        pcm=_silence_pcm(2.0),
+        segments=[Segment(0.0, 2.0, "speech")],
+    )
+    # Default — no progress wired
+    pipeline.run(input_path=input_path, output_path=output_path)
+
+    assert output_path.is_file()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -416,6 +416,8 @@ def test_pipeline_advances_each_phase_task_once_POD_013(tmp_path: Path) -> None:
         segments=segments,
     )
 
+    from unittest.mock import patch
+
     from podcast_script.progress import TaskID
 
     bar = make_progress()
@@ -426,10 +428,9 @@ def test_pipeline_advances_each_phase_task_once_POD_013(tmp_path: Path) -> None:
         advances.append((int(task_id), advance))
         real_advance(task_id, advance)
 
-    bar.advance = recording_advance  # type: ignore[method-assign]
     pipeline.progress = bar
-
-    pipeline.run(input_path=input_path, output_path=output_path)
+    with patch.object(bar, "advance", side_effect=recording_advance):
+        pipeline.run(input_path=input_path, output_path=output_path)
 
     decode_ticks = [a for a in advances if a[0] == DECODE_TASK]
     segment_ticks = [a for a in advances if a[0] == SEGMENT_TASK]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -416,13 +416,15 @@ def test_pipeline_advances_each_phase_task_once_POD_013(tmp_path: Path) -> None:
         segments=segments,
     )
 
+    from podcast_script.progress import TaskID
+
     bar = make_progress()
     advances: list[tuple[int, float]] = []
     real_advance = bar.advance
 
-    def recording_advance(task_id: object, advance: float = 1.0) -> None:
-        advances.append((int(task_id), advance))  # type: ignore[arg-type]
-        real_advance(task_id, advance)  # type: ignore[arg-type]
+    def recording_advance(task_id: TaskID, advance: float = 1.0) -> None:
+        advances.append((int(task_id), advance))
+        real_advance(task_id, advance)
 
     bar.advance = recording_advance  # type: ignore[method-assign]
     pipeline.progress = bar

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import io
 from typing import IO, cast
 
-import pytest
-
 from podcast_script import progress as progress_module
 from podcast_script.progress import (
     DECODE_TASK,
@@ -77,9 +75,7 @@ def test_make_progress_disabled_when_stderr_is_not_a_tty() -> None:
     assert pipe_stream.getvalue() == ""
 
 
-def test_make_progress_enabled_when_stderr_is_a_tty(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_make_progress_enabled_when_stderr_is_a_tty() -> None:
     """Inverse of the previous: a fake TTY-shaped stream gets a live
     bar. We don't render the bar here (transient, hard to assert),
     just verify it isn't disabled."""

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,123 @@
+"""Tests for ``progress.py`` (POD-013 — US-3 / ADR-0010).
+
+The module owns the construction of the :class:`rich.progress.Progress`
+instance the pipeline ticks during a run. Pipeline-level wiring +
+per-segment ticking lands in cycle B.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import IO, cast
+
+import pytest
+
+from podcast_script import progress as progress_module
+from podcast_script.progress import (
+    DECODE_TASK,
+    SEGMENT_TASK,
+    TRANSCRIBE_TASK,
+    make_progress,
+)
+
+
+def test_make_progress_registers_three_named_tasks_in_canonical_order() -> None:
+    """AC-US-3.1 — three named phases (decode, segment, transcribe).
+
+    Order matters because the bar renders top-to-bottom; the user
+    reads the run's lifecycle straight off the screen. Names are
+    locked because shell wrappers may grep them out of ``--debug``
+    captures.
+    """
+    bar = make_progress()
+
+    descriptions = [bar.tasks[i].description for i in range(len(bar.tasks))]
+
+    assert descriptions == ["decode", "segment", "transcribe"]
+    # Public constants for callers — keeps task lookup typed and
+    # protects against typos (a missed key = silently no-op tick).
+    assert bar.tasks[0].id == DECODE_TASK
+    assert bar.tasks[1].id == SEGMENT_TASK
+    assert bar.tasks[2].id == TRANSCRIBE_TASK
+
+
+def test_decode_and_segment_tasks_are_single_step_phases() -> None:
+    """Decode + segment are atomic — they either run or don't. Total =
+    1 so the bar shows 0% while running and 100% when advanced once.
+    Transcribe (per ADR-0010) gets its total set later when the
+    segmenter pass finishes; here it starts at 0 with no fixed total.
+    """
+    bar = make_progress()
+
+    assert bar.tasks[DECODE_TASK].total == 1
+    assert bar.tasks[SEGMENT_TASK].total == 1
+    # Transcribe total is set by the pipeline once it knows
+    # ``len(speech_segments)`` (ADR-0010); ``None`` means "not yet
+    # known" in rich's API.
+    assert bar.tasks[TRANSCRIBE_TASK].total is None
+
+
+def test_make_progress_disabled_when_stderr_is_not_a_tty() -> None:
+    """AC-US-3.2 — non-TTY stderr (piped to a file) must not paint
+    ANSI control sequences. Rich's Progress respects ``disable=True``
+    by suppressing all rendering. We pass an explicit non-TTY stream
+    so the test is hermetic from the runner's actual stderr state.
+    """
+    pipe_stream: io.StringIO = io.StringIO()  # not a TTY by definition
+    bar = make_progress(file=pipe_stream)
+
+    assert bar.disable is True
+    # Sanity — starting and advancing on a disabled bar is a no-op
+    # but must not raise. Shell wrappers piping stderr to a file
+    # should observe nothing from rich on stderr.
+    bar.start()
+    bar.advance(DECODE_TASK, 1)
+    bar.stop()
+
+    assert pipe_stream.getvalue() == ""
+
+
+def test_make_progress_enabled_when_stderr_is_a_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inverse of the previous: a fake TTY-shaped stream gets a live
+    bar. We don't render the bar here (transient, hard to assert),
+    just verify it isn't disabled."""
+
+    class _FakeTtyStream:
+        def isatty(self) -> bool:
+            return True
+
+        def write(self, _s: str) -> int:
+            return 0
+
+        def flush(self) -> None:
+            pass
+
+    # ``IO[str]`` is structural at runtime; the cast keeps mypy happy
+    # without forcing the fake to inherit from io.IOBase (which would
+    # bring in a half-dozen abstract methods we don't need).
+    bar = make_progress(file=cast("IO[str]", _FakeTtyStream()))
+
+    assert bar.disable is False
+
+
+def test_make_progress_factory_is_idempotent() -> None:
+    """Two calls return two distinct ``Progress`` instances. POD-014
+    + the cli composition root should be free to construct one per
+    run without spooky shared state.
+    """
+    a = make_progress()
+    b = make_progress()
+    assert a is not b
+    assert a.tasks[DECODE_TASK].id == b.tasks[DECODE_TASK].id  # canonical id
+
+
+def test_progress_module_re_exports_the_rich_progress_type() -> None:
+    """Callers should be able to type-annotate against the module's
+    re-export rather than reaching into ``rich.progress`` directly —
+    keeps the dep surface visible from one import in pipeline.py.
+    """
+    from rich.progress import Progress
+
+    assert progress_module.Progress is Progress


### PR DESCRIPTION
## Summary

Closes POD-013 under US-3, sprint SP-5. Adds the `rich.progress.Progress`-backed three-phase progress bar (decode / segment / transcribe) and wires it through `Pipeline` per ADR-0010 — backend-agnostic UX, identical on Linux/CUDA, Linux/CPU, and Apple Silicon.

## Acceptance criteria satisfied

- [x] **AC-US-3.1 (TTY)** — three named phases (decode, segment, transcribe) render in canonical order; transcribe ticks once per speech segment per ADR-0010 so percentage is meaningful regardless of backend yield cadence.
- [x] **AC-US-3.2 (non-TTY)** — when stderr isn't a TTY (pipe / CI capture), `make_progress` returns `Progress(disable=True)` — no ANSI, no live region, nothing on the captured stream. Locked by `tests/test_progress.py::test_make_progress_disabled_when_stderr_is_not_a_tty`.

## What changed

### `src/podcast_script/progress.py` (new)
Factory `make_progress(file=stderr)` returning a configured `rich.progress.Progress` with three pre-registered tasks. Public `DECODE_TASK` / `SEGMENT_TASK` / `TRANSCRIBE_TASK` `TaskID` constants protect callers from a typo silently no-op'ing a tick.

- decode + segment start with `total=1` (atomic phases — bar shows 0% running, 100% done).
- transcribe starts with `total=None`; the pipeline sets it to `len(speech_segments)` after the segmenter pass per ADR-0010.

### `src/podcast_script/pipeline.py`
- New `progress: Progress | None = None` field on `Pipeline`.
- When set, each phase method advances the corresponding task; per ADR-0010 transcribe ticks once per outer-loop iteration over speech segments.
- When `None` (Tier 1 default), all ticks are no-ops — existing pipeline tests pass unchanged.

### `src/podcast_script/cli.py`
Hoisted Progress creation up to `cli.main` so the log handler shares the Progress Console per ADR-0008 — without this, log lines and the live progress region render through two separate Consoles both targeting stderr, which tears on a real TTY.

Flow: `main` configures log → emits `startup`/`config_loaded`/`backend_selected` (pre-bar) → builds Progress → re-configures log with `progress=bar` → opens `with bar:` block → calls `_run_pipeline(progress=bar, ...)` → after the `with` block emits the locked `event=done` summary.

## Tests

Three Tier 1 tests in `tests/test_progress.py`:
1. Canonical order + locked task IDs.
2. Decode + segment are atomic (`total=1`); transcribe starts unset.
3. AC-US-3.2 non-TTY suppression — `disable=True` and stream sees no writes.
4. AC-US-3.1 TTY enablement — fake `isatty()=True` stream gets a live bar.
5. Factory idempotence — two calls return distinct instances.
6. Module re-exports `Progress` so callers don't reach into `rich.progress`.

Three Tier 1 tests in `tests/test_pipeline.py`:
1. Phase-tick counts match speech-segment counts (ADR-0010 backend-agnostic UX).
2. `transcribe.total` set to speech-segment count after segmenter pass.
3. `progress=None` default path keeps existing tests working unchanged.

## Test plan

- [x] `uv run --frozen pytest -q` — 218 passed, 2 deselected.
- [x] `uv run --frozen pytest -m slow` — 2 passed (~10 s) on the real LibriVox + CC0 fixture.
- [x] `uv run --frozen ruff check .` — clean.
- [x] `uv run --frozen ruff format --check .` — clean.
- [x] `uv run --frozen mypy --strict src tests` — clean.
- [x] Manual smoke: piping stderr to a file confirms no ANSI / progress noise (AC-US-3.2). The locked event catalogue lines + `event=done` summary still render in order.
- [ ] CI matrix (Ubuntu + macOS-14) — surfaces on push.
- [ ] Manual TTY check (interactive terminal) — confirm three named phases + per-segment ticks render without tearing the log lines.

## Definition of Done

- [x] Trunk-based feature branch, squash-merge target.
- [x] Tests green on detected toolchain locally.
- [ ] CI matrix green (surfaces on push).
- [ ] Stakeholder signoff at sprint review (post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)