### PR TITLE
feat(POD-014): -v/-q/--debug mutual-exclusion + verbosity matrix (US-3)

### DIFF
--- a/src/podcast_script/cli.py
+++ b/src/podcast_script/cli.py
@@ -41,7 +41,7 @@ import typer
 from . import config as _config
 from .backends.base import select_backend
 from .config import SUPPORTED_LANGS, validate_lang
-from .errors import InputIOError, OutputExistsError, PodcastScriptError
+from .errors import InputIOError, OutputExistsError, PodcastScriptError, UsageError
 from .logging_setup import configure
 from .pipeline import RunSummary
 from .progress import Progress, make_progress
@@ -114,10 +114,27 @@ def _check_output_path(resolved_output: Path, *, force: bool) -> None:
 def _resolve_verbosity(verbose: bool, quiet: bool, debug: bool) -> Verbosity:
     """Map the three flag booleans to a :data:`Verbosity` label.
 
-    Mutual-exclusion enforcement and a richer matrix land in POD-014
-    (SP-5); for POD-006 we just pick the strongest signal so log output
-    behaves consistently when more than one is passed by accident.
+    SRS §9.1 grammar — ``[-v, --verbose | -q, --quiet | --debug]`` —
+    documents the three flags as mutually exclusive: at most one may
+    be set. Combining any two is a :class:`UsageError` (exit 2 per
+    ADR-0006). The cli enforces this guard *before* any pipeline work
+    begins so a misconfigured invocation costs nothing more than an
+    error message.
+
+    Per AC-US-3.5, the resulting label drives the logger level via
+    :data:`podcast_script.logging_setup._LEVEL_FOR_VERBOSITY`:
+
+    * ``quiet``   — only ``level=error`` lines on stderr.
+    * ``normal``  — ``level=info`` and above + progress bar.
+    * ``verbose`` — ``level=debug`` and above + progress bar.
+    * ``debug``   — same level as verbose plus the artifact dir of
+      US-7 (POD-024 owns the dir-emission half).
     """
+    chosen = sum((verbose, quiet, debug))
+    if chosen > 1:
+        raise UsageError(
+            "--verbose (-v), --quiet (-q), and --debug are mutually exclusive; pass at most one"
+        )
     if debug:
         return "debug"
     if verbose:
@@ -247,17 +264,26 @@ def main(
     ] = False,
 ) -> None:
     """Transcribe a podcast audio file to Markdown with music-segment markers."""
-    verbosity = _resolve_verbosity(verbose, quiet, debug)
+    # Pre-configure with a permissive default so a UsageError raised by
+    # ``_resolve_verbosity`` (the SRS §9.1 mutual-exclusion guard) has a
+    # working logger to route through the cli's catch-and-translate
+    # handler. Re-configured with the resolved verbosity below if the
+    # guard passes.
+    verbosity: Verbosity = "normal"
     log = configure(verbosity, progress=None)
-
-    # ADR-0012 lifecycle — ``event=startup`` fires once argv has been
-    # parsed by typer and before any work begins. Lets shell wrappers
-    # see "tool started" before model load (which can take seconds on a
-    # cold cache).
-    log.info("", extra={"event": "startup"})
     wall_start = time.monotonic()
 
     try:
+        verbosity = _resolve_verbosity(verbose, quiet, debug)
+        log = configure(verbosity, progress=None)
+
+        # ADR-0012 lifecycle — ``event=startup`` fires once argv has been
+        # parsed by typer and before any work begins. Lets shell wrappers
+        # see "tool started" before model load (which can take seconds
+        # on a cold cache). Emitted under the resolved verbosity so
+        # ``--quiet`` correctly drops it (AC-US-3.5).
+        log.info("", extra={"event": "startup"})
+
         # POD-016 — load TOML defaults from the locked path (None = absent)
         # then merge with whatever the user typed on argv. ``cli_overrides``
         # carries every flag value as-is; entries with ``None`` mean

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -834,3 +834,135 @@ class TestEventCatalogue:
         assert events == ["startup", "config_loaded", "backend_selected", "done"], (
             f"unexpected event order; got {events!r}"
         )
+
+
+class TestVerbosityMatrix:
+    """POD-014 — SRS §9.1 grammar enforcement + AC-US-3.5 levels.
+
+    Mutual exclusion is documented as ``[-v, --verbose | -q, --quiet
+    | --debug]`` (SRS §9.1 line 423). Combining any two is a usage
+    error per ADR-0006 (exit 2). Within a single setting, the logger
+    level is what AC-US-3.5 commits to.
+    """
+
+    @pytest.mark.parametrize(
+        "flags",
+        [
+            ["-v", "-q"],
+            ["--verbose", "--quiet"],
+            ["-v", "--debug"],
+            ["--verbose", "--debug"],
+            ["-q", "--debug"],
+            ["--quiet", "--debug"],
+            ["-v", "-q", "--debug"],
+        ],
+    )
+    def test_combining_verbosity_flags_exits_2(
+        self, runner: CliRunner, tmp_path: Path, flags: list[str]
+    ) -> None:
+        """SRS §9.1 grammar — at most one of -v / -q / --debug. Combining
+        any two is a UsageError (exit 2)."""
+        input_file = _touch(tmp_path, "episode.mp3")
+        result = runner.invoke(app, [str(input_file), "--lang", "es", *flags])
+
+        assert result.exit_code == 2, f"flags={flags} stderr={result.stderr!r}"
+        assert "event=usage_error" in result.stderr
+        # Message must name the offending grammar rule so the user can
+        # self-correct.
+        for fragment in ("verbose", "quiet", "debug"):
+            assert fragment in result.stderr.lower(), (
+                f"missing {fragment!r}; flags={flags} stderr={result.stderr!r}"
+            )
+
+    def test_quiet_emits_no_info_events(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC-US-3.3 / AC-US-3.5 — ``-q`` filters ``level=info`` (and
+        below) so the lifecycle events (``startup`` / ``config_loaded``
+        / ``backend_selected`` / ``done``) don't surface. Only error
+        lines (none on the happy path) appear.
+        """
+        from podcast_script import cli as cli_module
+
+        monkeypatch.setattr(cli_module, "_run_pipeline", lambda **_: _RUN_SUMMARY_STUB)
+        input_file = _touch(tmp_path, "episode.mp3")
+
+        result = runner.invoke(app, [str(input_file), "--lang", "es", "-q"])
+
+        assert result.exit_code == 0, f"stderr={result.stderr!r}"
+        # No info lines means no podcast_script-emitted events at all on
+        # the happy path. Empty (or only whitespace) stderr is acceptable.
+        assert "level=info" not in result.stderr, f"stderr={result.stderr!r}"
+        assert "event=" not in result.stderr, f"stderr={result.stderr!r}"
+
+    def test_default_verbosity_emits_info_events(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC-US-3.5 default branch — ``level=info`` events visible on
+        a happy path. Sanity that the pre-existing lifecycle events
+        survive the verbosity-matrix refactor.
+        """
+        from podcast_script import cli as cli_module
+
+        monkeypatch.setattr(cli_module, "_run_pipeline", lambda **_: _RUN_SUMMARY_STUB)
+        input_file = _touch(tmp_path, "episode.mp3")
+
+        result = runner.invoke(app, [str(input_file), "--lang", "es"])
+
+        assert result.exit_code == 0, f"stderr={result.stderr!r}"
+        assert "level=info" in result.stderr
+        assert "event=startup" in result.stderr
+        assert "event=done" in result.stderr
+
+    @pytest.mark.parametrize("flag", ["-v", "--verbose", "--debug"])
+    def test_verbose_and_debug_set_logger_to_debug_level(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        flag: str,
+    ) -> None:
+        """AC-US-3.5 — ``-v`` ⇒ debug-and-above; ``--debug`` ⇒ same level
+        plus the artifact dir (POD-024 owns the dir). Both raise the
+        logger threshold to DEBUG so future debug-level emissions
+        surface.
+        """
+        import logging
+
+        from podcast_script import cli as cli_module
+
+        monkeypatch.setattr(cli_module, "_run_pipeline", lambda **_: _RUN_SUMMARY_STUB)
+        input_file = _touch(tmp_path, "episode.mp3")
+
+        result = runner.invoke(app, [str(input_file), "--lang", "es", flag])
+
+        assert result.exit_code == 0, f"flag={flag} stderr={result.stderr!r}"
+        # Level set on the package logger is what AC-US-3.5 commits to.
+        assert logging.getLogger("podcast_script").level == logging.DEBUG, (
+            f"flag={flag} expected logger at DEBUG level"
+        )
+
+    def test_non_tty_stderr_emits_no_ansi_AC_US_3_2(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC-US-3.2 — when stderr isn't a TTY (CliRunner captures, real
+        pipes), no ANSI escape sequences appear; the logfmt event
+        stream serves as the plain-text per-phase update.
+        """
+        from podcast_script import cli as cli_module
+
+        monkeypatch.setattr(cli_module, "_run_pipeline", lambda **_: _RUN_SUMMARY_STUB)
+        input_file = _touch(tmp_path, "episode.mp3")
+
+        result = runner.invoke(app, [str(input_file), "--lang", "es"])
+
+        assert result.exit_code == 0, f"stderr={result.stderr!r}"
+        # The standard ANSI ESC byte (\x1b) MUST NOT appear anywhere in
+        # captured stderr — that's the user's grep contract on a
+        # non-TTY pipe.
+        assert "\x1b" not in result.stderr, (
+            f"unexpected ANSI escape in non-TTY stderr; stderr={result.stderr!r}"
+        )
+        # …but the logfmt events still fire, so the user has the
+        # plain-text per-phase update AC-US-3.2 promises.
+        assert "level=info" in result.stderr


### PR DESCRIPTION
## Summary

Closes POD-014 under US-3, sprint SP-5. Enforces the SRS §9.1 `[-v, --verbose | -q, --quiet | --debug]` grammar at the cli surface, locks the AC-US-3.5 verbosity matrix levels, and pins AC-US-3.2's non-TTY ANSI-free contract with a regression test.

US-3 acceptance criteria are now all covered modulo POD-035 (PTY harness for AC-US-3.1 visual rendering) and POD-033 (logfmt regex CI assertion).

## Acceptance criteria satisfied

- [x] **SRS §9.1 grammar / mutual exclusion** — at most one of `-v`, `-q`, `--debug`. Combining any two raises `UsageError` (exit 2 per ADR-0006), surfaces as the locked `event=usage_error code=2` line. Locked by 7 parametrized test cases (`-v -q`, `-v --debug`, `-q --debug`, all-three, plus long-flag variants).
- [x] **AC-US-3.5 levels** — `_LEVEL_FOR_VERBOSITY` already mapped the four labels to `logging.{ERROR,INFO,DEBUG,DEBUG}`; this PR locks the contract with parametrized tests so a future label rename or level shift fails CI.
- [x] **AC-US-3.3** — `-q` produces zero podcast-script log lines on the happy path; the level filter at ERROR drops every `event=*` info line. The `--quiet` → no-Progress gate from POD-013's review-fix stays in place (cleanest way to honour AC-US-3.3).
- [x] **AC-US-3.2** — captured non-TTY stderr contains no ANSI escape bytes; the logfmt event stream serves as the plain-text per-phase update. Locked by `test_non_tty_stderr_emits_no_ansi_AC_US_3_2`.

## What changed

### `src/podcast_script/cli.py`

- `_resolve_verbosity` now raises `UsageError` when more than one of `verbose`/`quiet`/`debug` is set. Docstring spells out the AC-US-3.5 mapping for each label.
- `_resolve_verbosity` call moved *inside* the `try` block in `cli.main` so the UsageError reaches the cli's catch-and-translate handler. The logger is pre-configured with `"normal"` defaults so the `event=usage_error` line has a working handler before resolution succeeds.
- `event=startup` now fires under the **resolved** verbosity (so `--quiet` correctly drops it per AC-US-3.5).

### `tests/test_cli.py` — `TestVerbosityMatrix`
- 7 parametrized tests for illegal flag combinations.
- `test_quiet_emits_no_info_events` — happy-path quiet stderr is empty.
- `test_default_verbosity_emits_info_events` — sanity check.
- 3 parametrized tests for `-v` / `--verbose` / `--debug` setting the logger to DEBUG.
- `test_non_tty_stderr_emits_no_ansi_AC_US_3_2` — the AC-US-3.2 regression net.

## Out of scope (tracked elsewhere)

- **PTY/no-PTY harness** for AC-US-3.1's *visual* progress-bar rendering — POD-035 (SP-5).
- **logfmt regex CI assertion** — POD-033 (SP-5).
- **`--debug` artifact directory** — POD-024 (SP-6, US-7); the `--debug` flag's verbosity half is owned by POD-014, the dir-emission half by POD-024.

## Test plan

- [x] `uv run --frozen pytest -q` — 231 passed, 2 deselected.
- [x] `uv run --frozen pytest -m slow` — 2 passed (~10 s).
- [x] `uv run --frozen ruff check .` — clean.
- [x] `uv run --frozen ruff format --check .` — clean.
- [x] `uv run --frozen mypy --strict src tests` — clean.
- [x] Manual smoke: `podcast-script ... --lang es -v -q` exits 2 with the locked `event=usage_error` line.
- [ ] CI matrix (Ubuntu + macOS-14) — surfaces on push.

## Definition of Done

- [x] Trunk-based feature branch, squash-merge target.
- [x] Tests green on detected toolchain locally.
- [ ] CI matrix green (surfaces on push).
- [ ] Stakeholder signoff at sprint review (post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)