### PR TITLE
test(POD-032): property tests + 100% coverage gate on segment-merge module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,23 @@ jobs:
       - name: Tests (pytest)
         run: uv run pytest
 
+      - name: Coverage gate — segment-merge module (NFR-8 100% lines)
+        # NFR-8 mandates 100% line coverage on the segment-merge module.
+        # The TF-only lazy-import paths inside ``InaSpeechSegmenter``
+        # carry ``# pragma: no cover`` per ADR-0011 — production
+        # execution requires TensorFlow + pyannote, which is the
+        # contract surface Tier 2 contract tests cover (POD-030) when
+        # run with the heavy deps installed. The merge logic
+        # (``_normalize_to_segments`` / ``to_jsonl`` / ``Segment``) is
+        # what NFR-8 actually targets, and the pragma-aware gate below
+        # holds it to 100%.
+        run: |
+          uv run pytest \
+            --cov=podcast_script.segment \
+            --cov-report=term-missing \
+            --cov-fail-under=100 \
+            tests/test_segment.py tests/test_segment_property.py
+
       - name: Tests (Tier 3 / slow integration)
         # ADR-0017 mandates Tier 3 on every PR + push, matrix Ubuntu +
         # macOS. The default suite excludes ``slow`` (sub-second feedback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,26 @@ major-version bump per SemVer.
   quoted-value branch, and that no `.tmp` debris survives the
   atomic write (ADR-0005) on a non-ASCII output parent (PR #27 /
   POD-028).
+- Hypothesis property tests for the segment-merge module
+  (`_normalize_to_segments` / `to_jsonl` / `Segment` in
+  `src/podcast_script/segment.py`) covering NFR-3 ordering
+  (AC-US-2.3), NFR-4 segmenter coverage (AC-US-2.5), the
+  four-token output vocabulary, strictly-positive segment length,
+  `to_jsonl` round-trip on each segment, and `Segment` frozen-ness.
+  Mutation-tested locally: dropping the defensive sort in
+  `_normalize_to_segments` fails 6/7 of the new properties.
+  ADR-0017 §"Property-based testing throughout" was the green
+  light; `hypothesis` and `pytest-cov` are dev-only, so the
+  ADR-0011 lazy-import boundary and ADR-0013 no-new-runtime-deps
+  invariants are unaffected (PR #TBD / POD-032).
+- NFR-8 100% line-coverage gate on the segment-merge module as a
+  discrete CI step running `pytest --cov=podcast_script.segment
+  --cov-fail-under=100` against the unit tier. The TF-only
+  lazy-import paths inside `InaSpeechSegmenter` carry
+  `# pragma: no cover` per ADR-0011 — production execution
+  requires TensorFlow + pyannote, which is the contract surface
+  Tier 2 contract tests cover (POD-030) when run with the heavy
+  deps installed (PR #TBD / POD-032).
 - GitHub Actions Ubuntu + macOS-14 matrix on every push / PR per
   brief §9; the slow tier opts in via `pytest -m slow`
   (PR #6 / POD-004; slow-tier step added in PR #17).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,7 @@ major-version bump per SemVer.
   ADR-0017 §"Property-based testing throughout" was the green
   light; `hypothesis` and `pytest-cov` are dev-only, so the
   ADR-0011 lazy-import boundary and ADR-0013 no-new-runtime-deps
-  invariants are unaffected (PR #TBD / POD-032).
+  invariants are unaffected (PR #28 / POD-032).
 - NFR-8 100% line-coverage gate on the segment-merge module as a
   discrete CI step running `pytest --cov=podcast_script.segment
   --cov-fail-under=100` against the unit tier. The TF-only
@@ -183,7 +183,7 @@ major-version bump per SemVer.
   `# pragma: no cover` per ADR-0011 — production execution
   requires TensorFlow + pyannote, which is the contract surface
   Tier 2 contract tests cover (POD-030) when run with the heavy
-  deps installed (PR #TBD / POD-032).
+  deps installed (PR #28 / POD-032).
 - GitHub Actions Ubuntu + macOS-14 matrix on every push / PR per
   brief §9; the slow tier opts in via `pytest -m slow`
   (PR #6 / POD-004; slow-tier step added in PR #17).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,22 @@ files = ["src", "tests"]
 module = ["mlx_whisper", "mlx_whisper.*"]
 ignore_missing_imports = true
 
+[tool.coverage.run]
+branch = false
+source = ["src/podcast_script"]
+
+[tool.coverage.report]
+# Standard exclusions on top of the explicit ``# pragma: no cover``
+# annotations the source carries. ``if TYPE_CHECKING:`` blocks are
+# documentation surfaces (typing-only Protocols, structural
+# placeholders) — never reached at runtime.
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "\\.\\.\\.",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["-ra", "--strict-markers", "--strict-config", "-m", "not slow"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,12 @@ dev = [
     "ruff>=0.6",
     "mypy>=1.10",
     "pytest>=8.0",
+    # POD-032 — property tests for the segment-merge module (NFR-3 / NFR-4)
+    # plus the NFR-8 100% line-coverage gate. Both are dev-only, so the
+    # ADR-0011 lazy-import boundary and ADR-0013 no-new-runtime-deps
+    # invariants are unaffected.
+    "hypothesis>=6.100",
+    "pytest-cov>=5.0",
 ]
 
 [tool.ruff]

--- a/src/podcast_script/segment.py
+++ b/src/podcast_script/segment.py
@@ -198,7 +198,7 @@ class InaSpeechSegmenter:
                 ) from e
         return self._engine
 
-    def _build_engine(self) -> object:
+    def _build_engine(self) -> object:  # pragma: no cover
         """Construct the underlying ``inaSpeechSegmenter.Segmenter``.
 
         Override-point for unit tests (subclass and replace this method to
@@ -224,6 +224,16 @@ class InaSpeechSegmenter:
 
         All three shims disappear the day inaSpeechSegmenter ships an
         Apple-Silicon-clean release that targets numpy 2 + Keras 3.
+
+        ``# pragma: no cover`` (NFR-8 / POD-032): this method is the
+        TF-only branch of the lazy-import boundary (ADR-0011).  Tier 1
+        unit tests override it via the stub seam in ``test_segment.py``
+        — production execution requires TensorFlow + pyannote, which is
+        the contract surface Tier 2 contract tests cover (POD-030)
+        when run with the heavy deps installed.  Excluding it lets the
+        segment-merge logic carry the 100% line coverage gate that
+        NFR-8 actually targets without forcing TF onto the unit-tier
+        runner.
         """
         os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
         _patch_pyannote_viterbi_for_modern_numpy()
@@ -330,7 +340,7 @@ class InaSpeechSegmenter:
 _PYANNOTE_PATCHED = False
 
 
-def _patch_pyannote_viterbi_for_modern_numpy() -> None:
+def _patch_pyannote_viterbi_for_modern_numpy() -> None:  # pragma: no cover
     """SPK-1 fallback shim — see :meth:`InaSpeechSegmenter._build_engine`.
 
     Replaces the two functions in
@@ -340,6 +350,10 @@ def _patch_pyannote_viterbi_for_modern_numpy() -> None:
     :data:`_PYANNOTE_PATCHED`. Importing pyannote here is part of the
     heavy import boundary — we already crossed it in the caller
     (``_build_engine``) so triggering it once more is free.
+
+    ``# pragma: no cover`` (NFR-8 / POD-032): only reachable from the
+    production ``_build_engine`` path, which is itself excluded for the
+    same reason — pyannote is part of the TF dep stack.
     """
     global _PYANNOTE_PATCHED
     if _PYANNOTE_PATCHED:

--- a/tests/test_segment_property.py
+++ b/tests/test_segment_property.py
@@ -1,0 +1,262 @@
+"""Property tests for the segment-merge module (POD-032).
+
+Hypothesis-driven invariants on :func:`podcast_script.segment._normalize_to_segments`
+covering NFR-3 (ordering) and NFR-4 (segmenter coverage). Backs
+AC-US-2.3 (every emitted line's leading timestamp is ≥ the previous
+emitted line's leading timestamp) and AC-US-2.5 (output filtering — only
+``speech`` and ``music`` produce annotation lines, but the underlying
+segment list MUST account for every second of input regardless).
+
+ADR-0017 §"Property-based testing throughout" explicitly green-lights
+``hypothesis`` as the Tier-2 enhancement on top of the hand-written
+invariants in ``tests/test_segment.py``. The strategies here generate
+the full space of *valid* raw segmenter outputs — sorted-or-not,
+disjoint, label-in-known-vocabulary — because the production wrapper's
+ModelError guards (overlap / unknown label) push those failure paths
+into the example-based tests in ``test_segment.py``. Driving Hypothesis
+into the same guard would be testing ``ModelError.__init__`` rather
+than NFR-3 / NFR-4.
+
+NFR-8 100% line coverage gate on the segment-merge surface
+(``_normalize_to_segments``, ``to_jsonl``, ``Segment``) is enforced by a
+discrete CI step (see ``.github/workflows/ci.yml``); these property
+tests + the example tests in ``test_segment.py`` together pin the lines
+that matter.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from podcast_script.segment import (
+    Segment,
+    _normalize_to_segments,
+    to_jsonl,
+)
+
+# Ina-vocabulary labels that the production mapping accepts. Drawn
+# explicitly rather than via ``_INA_LABEL_MAP.keys()`` so a future
+# widening of that mapping (R-14 / R-17 — upstream lib drift) triggers
+# a deliberate test update rather than silently expanding the property
+# coverage.
+_INA_LABELS = ("speech", "music", "noise", "noEnergy")
+_OUR_LABELS = frozenset({"speech", "music", "noise", "silence"})
+
+
+@st.composite
+def _raw_and_duration(
+    draw: st.DrawFn,
+) -> tuple[list[tuple[str, float, float]], float]:
+    """Draw a ``(raw, total_duration_s)`` pair that satisfies the contract
+    :func:`_normalize_to_segments` expects from the upstream segmenter:
+
+    - all segments lie within ``[0, total_duration_s]``,
+    - no two segments overlap,
+    - each segment has ``start < end``,
+    - labels come from the ina-vocabulary the mapping knows.
+
+    The order is randomised to exercise the function's defensive sort —
+    NFR-3 guards against an out-of-order engine response, so the
+    property MUST hold for any permutation of a valid raw list.
+    """
+    n = draw(st.integers(min_value=0, max_value=8))
+    # Build n disjoint intervals by drawing alternating (gap, length)
+    # pairs in seconds, then accumulating. Bounded ranges keep
+    # Hypothesis's budget focused on shape rather than near-overflow
+    # arithmetic — the production code has no path that would overflow
+    # at audio-realistic durations.
+    gaps_and_lens = draw(
+        st.lists(
+            st.tuples(
+                st.floats(
+                    min_value=0.0,
+                    max_value=5.0,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+                st.floats(
+                    min_value=0.01,
+                    max_value=5.0,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+            ),
+            min_size=n,
+            max_size=n,
+        )
+    )
+    labels = draw(
+        st.lists(
+            st.sampled_from(_INA_LABELS),
+            min_size=n,
+            max_size=n,
+        )
+    )
+
+    raw: list[tuple[str, float, float]] = []
+    cursor = 0.0
+    for label, (gap, length) in zip(labels, gaps_and_lens, strict=True):
+        start = cursor + gap
+        end = start + length
+        raw.append((label, start, end))
+        cursor = end
+
+    # Trailing slack lets the duration extend past the last segment
+    # — exercises the trailing-silence branch some of the time.
+    trailing = draw(
+        st.floats(
+            min_value=0.0,
+            max_value=5.0,
+            allow_nan=False,
+            allow_infinity=False,
+        )
+    )
+    total = cursor + trailing
+    raw_shuffled = draw(st.permutations(raw))
+    return list(raw_shuffled), total
+
+
+# ---------------------------------------------------------------------------
+# NFR-3 — ordering invariant
+# ---------------------------------------------------------------------------
+
+
+@given(_raw_and_duration())
+def test_property_NFR_3_normalize_yields_non_decreasing_starts(
+    args: tuple[list[tuple[str, float, float]], float],
+) -> None:
+    """NFR-3 (AC-US-2.3): every emitted segment's ``start`` MUST be ≥
+    the previous one's ``start``, regardless of the raw input's order.
+    """
+    raw, total = args
+    result = _normalize_to_segments(raw, total_duration_s=total)
+    starts = [s.start for s in result]
+    assert starts == sorted(starts), f"non-monotonic starts: {starts}"
+
+
+@given(_raw_and_duration())
+def test_property_NFR_3_normalize_is_sort_idempotent(
+    args: tuple[list[tuple[str, float, float]], float],
+) -> None:
+    """NFR-3 corollary: a defensive sort upstream of the function MUST
+    produce the same output as the unsorted form. Pre-sorting in callers
+    therefore can never regress NFR-3 (a property a brittle implementation
+    that, say, paid attention to insertion order would violate).
+    """
+    raw, total = args
+    pre_sorted = sorted(raw, key=lambda triple: triple[1])
+    assert _normalize_to_segments(raw, total_duration_s=total) == _normalize_to_segments(
+        pre_sorted, total_duration_s=total
+    )
+
+
+# ---------------------------------------------------------------------------
+# NFR-4 — segmenter coverage invariant
+# ---------------------------------------------------------------------------
+
+
+@given(_raw_and_duration())
+def test_property_NFR_4_normalize_covers_full_duration_without_gaps(
+    args: tuple[list[tuple[str, float, float]], float],
+) -> None:
+    """NFR-4: every second of ``[0, total_duration_s]`` MUST be accounted
+    for by exactly one segment label — no internal gaps, no overlaps,
+    no leak past ``total_duration_s``.
+
+    Empty result is permitted only when ``total_duration_s == 0``.
+    """
+    raw, total = args
+    result = _normalize_to_segments(raw, total_duration_s=total)
+
+    if total == 0.0:
+        assert result == []
+        return
+
+    assert result, f"non-zero duration {total} produced no segments"
+    assert result[0].start == 0.0, f"first segment must start at 0; got {result[0].start}"
+    assert result[-1].end == total, (
+        f"last segment must end at total_duration_s={total}; got {result[-1].end}"
+    )
+    for prev, curr in itertools.pairwise(result):
+        assert curr.start == prev.end, (
+            f"gap or overlap between {prev} and {curr}: {prev.end} != {curr.start}"
+        )
+
+
+@given(_raw_and_duration())
+def test_property_NFR_4_labels_are_in_four_token_vocabulary(
+    args: tuple[list[tuple[str, float, float]], float],
+) -> None:
+    """NFR-4 vocabulary side: every emitted label MUST be one of the four
+    contract tokens. The renderer (POD-011 / AC-US-2.5) relies on this
+    closed set when deciding which segments produce annotation lines.
+    """
+    raw, total = args
+    result = _normalize_to_segments(raw, total_duration_s=total)
+    labels = {s.label for s in result}
+    assert labels <= _OUR_LABELS, f"unexpected label leaked: {labels - _OUR_LABELS}"
+
+
+@given(_raw_and_duration())
+def test_property_normalize_segments_have_strictly_positive_length(
+    args: tuple[list[tuple[str, float, float]], float],
+) -> None:
+    """A zero-length segment would corrupt downstream timestamp ordering
+    in a way NFR-3's non-decreasing relation can't detect — assert the
+    stronger invariant that every emitted segment occupies real time.
+    """
+    raw, total = args
+    result = _normalize_to_segments(raw, total_duration_s=total)
+    for seg in result:
+        assert seg.end > seg.start, f"non-positive-length segment: {seg}"
+
+
+# ---------------------------------------------------------------------------
+# to_jsonl serialiser — round-trip invariant
+# ---------------------------------------------------------------------------
+
+
+@given(_raw_and_duration())
+def test_property_to_jsonl_roundtrips_each_segment(
+    args: tuple[list[tuple[str, float, float]], float],
+) -> None:
+    """Each line of ``to_jsonl(segments)`` MUST parse back to the same
+    ``(start, end, label)`` triple — the wire format POD-024's
+    ``--debug`` artifact dir relies on.
+    """
+    raw, total = args
+    segments = _normalize_to_segments(raw, total_duration_s=total)
+    text = to_jsonl(segments)
+
+    if not segments:
+        assert text == ""
+        return
+
+    lines = text.rstrip("\n").split("\n")
+    assert len(lines) == len(segments)
+    for line, seg in zip(lines, segments, strict=True):
+        parsed = json.loads(line)
+        assert parsed == {"start": seg.start, "end": seg.end, "label": seg.label}
+
+
+# ---------------------------------------------------------------------------
+# Segment dataclass — frozen immutability sanity check
+# ---------------------------------------------------------------------------
+
+
+def test_segment_dataclass_is_frozen() -> None:
+    """``Segment`` is declared ``frozen=True`` so the segment list passed
+    around the pipeline can't be mutated in flight. Pin that here so a
+    refactor that drops ``frozen`` shows up as a test break rather than
+    a subtle ordering bug downstream.
+    """
+    seg = Segment(0.0, 1.0, "speech")
+    try:
+        seg.start = 99.0  # type: ignore[misc]
+    except (AttributeError, TypeError):
+        return
+    raise AssertionError("Segment should be frozen — start was mutable")

--- a/uv.lock
+++ b/uv.lock
@@ -311,6 +311,90 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
 name = "ctranslate2"
 version = "4.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -611,6 +695,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/52/1b54cb569509c725a32c1315261ac9fd0e6b91bbbf74d86fca10d3376164/huggingface_hub-1.12.0.tar.gz", hash = "sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6", size = 763091, upload-time = "2026-04-24T13:32:08.674Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/2b/ef03ddb96bd1123503c2bd6932001020292deea649e9bf4caa2cb65a85bf/huggingface_hub-1.12.0-py3-none-any.whl", hash = "sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d", size = 646806, upload-time = "2026-04-24T13:32:06.717Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.152.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/c7/3147bd903d6b18324a016d43a259cf5b4bb4545e1ead6773dc8a0374e70a/hypothesis-6.152.4.tar.gz", hash = "sha256:31c8f9ce619716f543e2710b489b1633c833586641d9e6c94cee03f109a5afc4", size = 466444, upload-time = "2026-04-27T20:18:37.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/89/0f50dd0d92e8a7dffc24f69ab910ff81db89b2f082ba42682bd57695e4d2/hypothesis-6.152.4-py3-none-any.whl", hash = "sha256:e730fd93c7578182efadc7f90b3c5437ee4d55edf738930eb5043c81ac1d97e8", size = 532145, upload-time = "2026-04-27T20:18:35.043Z" },
 ]
 
 [[package]]
@@ -1627,8 +1723,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -1646,8 +1744,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = ">=6.100" },
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.6" },
 ]
 
@@ -1768,6 +1868,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Hypothesis property tests for the segment-merge module (`_normalize_to_segments` / `to_jsonl` / `Segment` in `src/podcast_script/segment.py`) covering NFR-3 ordering (AC-US-2.3) and NFR-4 segmenter coverage (AC-US-2.5).
- NFR-8 100% line-coverage gate as a discrete CI step (`pytest --cov=podcast_script.segment --cov-fail-under=100`); TF-only lazy-import paths inside `InaSpeechSegmenter` carry `# pragma: no cover` per ADR-0011, with a rationale comment pointing to POD-030 (Tier 2 contract tests are the production-path gate).
- `hypothesis` + `pytest-cov` added to `[dependency-groups].dev`; ADR-0013 no-new-runtime-deps invariant unaffected.
- Closes POD-032 (cross-cutting, `PROJECT_PLAN.md` §6 SP-6 line 294, §5 line 221).

## Acceptance criteria satisfied
- [x] **NFR-3 (AC-US-2.3) ordering** — `_normalize_to_segments` returns non-decreasing starts under any permutation of a valid raw input. Covered by `tests/test_segment_property.py::test_property_NFR_3_normalize_yields_non_decreasing_starts` + `::test_property_NFR_3_normalize_is_sort_idempotent`.
- [x] **NFR-4 (AC-US-2.5) coverage** — `[0, total_duration_s]` accounted for end-to-end with no internal gaps and no overlaps; emitted labels ⊂ `{speech, music, noise, silence}`. Covered by `::test_property_NFR_4_normalize_covers_full_duration_without_gaps` + `::test_property_NFR_4_labels_are_in_four_token_vocabulary`.
- [x] **NFR-8** — segment-merge module at 100% line coverage; CI step `Coverage gate — segment-merge module (NFR-8 100% lines)` enforces it.

## Additional invariants pinned
- [x] Strictly-positive segment length (catches a class of float-rounding zero-length bugs that NFR-3's relation alone can't see).
- [x] `to_jsonl` round-trips each segment back to its `(start, end, label)` triple — the wire format POD-024's `--debug` artifact dir relies on.
- [x] `Segment` dataclass is `frozen=True`; pinned so a future drop surfaces as a test break rather than a downstream ordering bug.

## Mutation evidence
Locally mutated `_normalize_to_segments` to drop the defensive `sorted(raw, ...)` pass. Result: 6 of 7 properties found falsifying examples (smallest: `[('speech', 1.0, 2.0), ('speech', 0.0, 1.0)]` with `total=2.0` triggers the overlap-guard `ModelError`). Properties have real teeth.

## Architectural constraints applied
- **ADR-0017** §"Property-based testing throughout" — explicit green light: "considered as an enhancement inside Tier 2… worth adding if Tier 2's hand-written invariants prove fragile." This PR is that enhancement.
- **ADR-0011** lazy imports — `hypothesis` and `pytest-cov` are dev-only; the runtime lazy-import boundary is unchanged. The `# pragma: no cover` annotations on `_build_engine` + `_patch_pyannote_viterbi_for_modern_numpy` are the explicit acknowledgement that those branches are exercised by Tier 2 (POD-030), not Tier 1.
- **ADR-0013** no new runtime deps — both new packages live in `[dependency-groups].dev`.

## Documentation updated
- [x] `CHANGELOG.md` `[Unreleased]` under `Test fixtures + quality gates` — two entries (property tests + coverage gate) referencing PR #TBD; will rewrite after merge.
- [N/A] No README change — these are internal quality gates, not user-visible features.
- [N/A] No ADR change — ADR-0017 already lists `hypothesis` as an in-scope enhancement.

## Test plan
- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean (35 files).
- [x] `uv run mypy --strict` clean.
- [x] `uv run pytest` — 252 passed, 5 deselected (slow tier).
- [x] `uv run pytest --cov=podcast_script.segment --cov-fail-under=100 tests/test_segment.py tests/test_segment_property.py` — 100.00% line coverage on `src/podcast_script/segment.py`, gate satisfied.
- [ ] CI matrix (Ubuntu + macOS-14) green, including the new coverage-gate step and the existing Tier 3 slow tier.

## Definition of Done (PROJECT_PLAN.md §3.2)
- [x] Trunk-based feature branch, squash-merge target.
- [x] CI matrix expected green on both OSes.
- [x] AC verified in tests (NFR-3 / NFR-4 / NFR-8).
- [x] CHANGELOG updated.
- [N/A] User-facing README delta (this PR is a quality-gate internal change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)