### PR TITLE
test(POD-030): Tier 2 contract tests for WhisperBackend Protocol + R-14 latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,17 @@ jobs:
             --cov-fail-under=100 \
             tests/test_segment.py tests/test_segment_property.py
 
+      - name: Tests (Tier 2 / contract)
+        # ADR-0017 mandates Tier 2 on every PR + push, matrix Ubuntu +
+        # macOS. The default suite excludes ``contract`` (keeps the
+        # unit-tier feedback loop sub-second); this step opts in. The
+        # parametrized backend fixture skips real-backend params on
+        # ImportError per ADR-0011 — so on Ubuntu the ``mlx-whisper``
+        # parametrisation is skipped (PEP 508 marker excludes it from
+        # ``uv sync`` outside darwin/arm64), and on macOS-14 both real
+        # backends run. FakeBackend always runs. POD-030.
+        run: uv run pytest -m contract -v
+
       - name: Tests (Tier 3 / slow integration)
         # ADR-0017 mandates Tier 3 on every PR + push, matrix Ubuntu +
         # macOS. The default suite excludes ``slow`` (sub-second feedback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,29 @@ major-version bump per SemVer.
   light; `hypothesis` and `pytest-cov` are dev-only, so the
   ADR-0011 lazy-import boundary and ADR-0013 no-new-runtime-deps
   invariants are unaffected (PR #28 / POD-032).
+- Tier 2 contract tests under `tests/contract/` asserting the
+  `WhisperBackend` Protocol invariants identically against
+  `FakeBackend` plus each importable real backend
+  (`FasterWhisperBackend` / `MlxWhisperBackend`) per ADR-0017 —
+  empty-PCM yields empty Iterable, silence input does not raise,
+  yielded `TranscribedSegment.start` values are non-decreasing,
+  `transcribe()` is repeatable on a single instance after one
+  `load()`, and underlying load failures wrap as `ModelError`
+  (with `KeyboardInterrupt` propagating untouched per ADR-0014).
+  R-14 mitigation: a synthetic-cache-miss latency contract test
+  asserts the locked `event=model_download` notice fires within
+  1 s of `load()` entry AND before the slow build path (the
+  ordering check is what makes the contract load-bearing — the
+  formal 1-s budget alone misses a notice-after-build regression).
+  Real backends use the `_build_model` override seam (matching
+  POD-019 / POD-020 / POD-021's Tier 1 pattern) to keep the suite
+  network-free; reusable `FakeBackend` lives at `tests/fakes/whisper.py`.
+  Mutation-tested locally — every invariant catches a distinct
+  regression class without false positives on the others. Marked
+  `pytest.mark.contract` (excluded from the default suite; opt in
+  via `pytest -m contract`); a discrete CI step runs the contract
+  tier on the Ubuntu + macOS-14 matrix per ADR-0017 (PR #TBD /
+  POD-030).
 - NFR-8 100% line-coverage gate on the segment-merge module as a
   discrete CI step running `pytest --cov=podcast_script.segment
   --cov-fail-under=100` against the unit tier. The TF-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,7 +197,7 @@ major-version bump per SemVer.
   regression class without false positives on the others. Marked
   `pytest.mark.contract` (excluded from the default suite; opt in
   via `pytest -m contract`); a discrete CI step runs the contract
-  tier on the Ubuntu + macOS-14 matrix per ADR-0017 (PR #TBD /
+  tier on the Ubuntu + macOS-14 matrix per ADR-0017 (PR #29 /
   POD-030).
 - NFR-8 100% line-coverage gate on the segment-merge module as a
   discrete CI step running `pytest --cov=podcast_script.segment

--- a/README.md
+++ b/README.md
@@ -340,16 +340,20 @@ The project follows a three-tier test strategy (ADR-0017):
 - **Tier 1 — unit + fakes.** Pure logic exercised against in-memory
   fakes; sub-second total. Default `pytest` invocation.
 - **Tier 2 — contract.** `WhisperBackend` Protocol invariants run
-  against both `FakeBackend` AND the real backends (POD-030, in
-  progress). Run alongside Tier 1 when present.
+  against `FakeBackend` AND each real backend (`faster-whisper`,
+  `mlx-whisper`); real-backend parametrisations skip cleanly when
+  their library is not importable. Marked `pytest.mark.contract` so
+  the unit tier stays sub-second; CI runs Tier 2 on the Ubuntu +
+  macOS-14 matrix.
 - **Tier 3 — integration.** Full CLI on `examples/sample.mp3` with
   the real `faster-whisper` `tiny` model. Marked `pytest.mark.slow`
   so the unit tier stays sub-second.
 
 ```sh
-uv run pytest                     # Tier 1 (+ Tier 2 when present), default
+uv run pytest                     # Tier 1 (default — sub-second)
+uv run pytest -m contract         # Tier 2 (real backends on the host)
 uv run pytest -m slow             # Tier 3 (real CLI on examples/sample.mp3)
-uv run pytest -m "slow or not slow"   # everything (CI does this)
+uv run pytest -m "contract or slow or not slow"   # everything (CI does this)
 
 uv run ruff check .               # lint
 uv run ruff format --check .      # format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ exclude_lines = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = ["-ra", "--strict-markers", "--strict-config", "-m", "not slow"]
+addopts = ["-ra", "--strict-markers", "--strict-config", "-m", "not slow and not contract"]
 # Warnings policy — NFR-10 (logfmt key=value on stderr only). Anything
 # that escapes the runtime suppression in `InaSpeechSegmenter` is a real
 # regression: it leaks Python warnings into the user's pipe and breaks
@@ -111,4 +111,12 @@ markers = [
     # `pytest -m "slow or not slow"`. CI runs the slow suite on a
     # separate job so the unit-tier feedback loop stays sub-second.
     "slow: end-to-end tests that decode + transcribe; require ffmpeg + a Whisper model on disk",
+    # Tier 2 contract tests asserting the WhisperBackend Protocol
+    # invariants run identically against FakeBackend + each real
+    # backend (POD-030, ADR-0017). Skipped by default — opt in with
+    # `pytest -m contract`. CI runs the contract suite on a dedicated
+    # step (Ubuntu + macOS-14 matrix) so the unit-tier feedback loop
+    # stays sub-second; real-backend parametrisations skip cleanly when
+    # their library is not importable per ADR-0011.
+    "contract: WhisperBackend Protocol invariants run vs FakeBackend + real backends (Tier 2)",
 ]

--- a/tests/contract/__init__.py
+++ b/tests/contract/__init__.py
@@ -1,0 +1,9 @@
+"""Tier 2 contract tests (POD-030, ADR-0017).
+
+A shared parametrized suite asserting :class:`WhisperBackend` Protocol
+invariants identically against ``FakeBackend`` and each real backend
+(``FasterWhisperBackend`` / ``MlxWhisperBackend``). Real-backend
+parametrisations skip cleanly when their library is not importable per
+ADR-0011 — so a Linux developer's ``pytest -m contract`` works without
+``mlx_whisper`` installed; CI runs the matrix with both libs present.
+"""

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -25,6 +25,7 @@ from podcast_script.backends.base import WhisperBackend
 from tests.fakes.whisper import FakeBackend
 
 BackendFactory = Callable[[], WhisperBackend]
+FailingBackendFactory = Callable[[BaseException], WhisperBackend]
 
 _FASTER_TINY_MODEL = "tiny"
 # mlx-whisper expects a full HF repo ID — bare ``"tiny"`` 404s. The
@@ -120,4 +121,89 @@ def backend_factory(request: pytest.FixtureRequest) -> BackendFactory:
     once per backend in :func:`_backend_params`.
     """
     factory: BackendFactory = request.param
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Failing-load fixture (invariant I5)
+# ---------------------------------------------------------------------------
+
+
+def _failing_fake_factory(failure: BaseException) -> WhisperBackend:
+    return FakeBackend(load_failure=failure)
+
+
+def _failing_faster_factory(failure: BaseException) -> WhisperBackend:
+    """Return a faster-whisper backend whose ``_build_model`` raises ``failure``.
+
+    Uses the same override seam Tier 1 unit tests use (POD-019). The
+    contract under test is the wrap inside :meth:`load` that turns any
+    underlying failure into :class:`ModelError`; the seam keeps us off
+    the real network and CTranslate2 chain while still exercising the
+    production ``except Exception`` branch.
+    """
+    from podcast_script.backends.faster import FasterWhisperBackend
+
+    class _FailingFaster(FasterWhisperBackend):
+        def _build_model(self, model: str, device: str) -> object:
+            raise failure
+
+    return _FailingFaster()
+
+
+def _failing_mlx_factory(failure: BaseException) -> WhisperBackend:
+    """Mirror of ``_failing_faster_factory`` for the mlx backend."""
+    from podcast_script.backends.mlx import MlxWhisperBackend
+
+    class _FailingMlx(MlxWhisperBackend):
+        def _build_model(self, model: str, device: str) -> object:
+            raise failure
+
+    return _FailingMlx()
+
+
+def _failing_backend_params() -> list[object]:
+    """Per-backend factories that take a failure exception and yield a
+    backend whose ``load()`` will raise that exception through the
+    underlying seam. Skip-on-ImportError matches :func:`_backend_params`
+    so the matrix shape is identical.
+    """
+    params: list[object] = [
+        pytest.param(_failing_fake_factory, id="fake-whisper"),
+    ]
+    if importlib.util.find_spec("faster_whisper") is not None:
+        params.append(pytest.param(_failing_faster_factory, id="faster-whisper"))
+    else:
+        params.append(
+            pytest.param(
+                _failing_faster_factory,
+                id="faster-whisper",
+                marks=pytest.mark.skip(reason="faster_whisper not importable"),
+            )
+        )
+    if importlib.util.find_spec("mlx_whisper") is not None:
+        params.append(pytest.param(_failing_mlx_factory, id="mlx-whisper"))
+    else:
+        params.append(
+            pytest.param(
+                _failing_mlx_factory,
+                id="mlx-whisper",
+                marks=pytest.mark.skip(reason="mlx_whisper not importable"),
+            )
+        )
+    return params
+
+
+@pytest.fixture(params=_failing_backend_params())
+def failing_backend_factory(request: pytest.FixtureRequest) -> FailingBackendFactory:
+    """Return a callable that builds a backend pre-wired to fail on load.
+
+    The caller passes the failure exception (e.g.
+    ``ConnectionError("boom")`` for AC-US-5.4-shaped scenarios); the
+    factory routes through each backend's load-time seam so the
+    ``except Exception`` wrap inside :meth:`load` is the code path
+    actually exercised. The Tier 2 contract is "every backend
+    surfaces this as :class:`ModelError`, never as the raw exception".
+    """
+    factory: FailingBackendFactory = request.param
     return factory

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -1,0 +1,123 @@
+"""Parametrized backend fixture for Tier 2 contract tests (POD-030).
+
+Each contract test receives a ``backend_factory`` callable that returns
+a freshly :meth:`~podcast_script.backends.base.WhisperBackend.load`-ed
+instance, parametrized over ``FakeBackend`` plus each real backend
+whose library is importable on the current host. The skip-on-ImportError
+gate per ADR-0011 keeps the suite runnable on a Linux dev machine
+without ``mlx_whisper`` installed; CI runs the Ubuntu + macOS-14 matrix
+where both libs are present.
+
+Real backends use ``--model tiny`` per ADR-0017 §Tier 2 to keep wall
+time tractable (~10-30 s per test on a cold cache; near-instant once
+the HF cache is warm). The factory returns the backend already loaded
+so individual tests stay focused on the ``transcribe`` contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from collections.abc import Callable
+
+import pytest
+
+from podcast_script.backends.base import WhisperBackend
+from tests.fakes.whisper import FakeBackend
+
+BackendFactory = Callable[[], WhisperBackend]
+
+_FASTER_TINY_MODEL = "tiny"
+# mlx-whisper expects a full HF repo ID — bare ``"tiny"`` 404s. The
+# sibling ``_is_cached`` anchors on the ``/whisper-{model}`` convention
+# but ``_build_model`` does not normalise; tracked as a follow-up in
+# .task/POD-030.md (out of POD-030 scope; this is a US-5 bug).
+_MLX_TINY_MODEL = "mlx-community/whisper-tiny"
+_REAL_DEVICE = "cpu"
+
+
+def _fake_backend_factory() -> WhisperBackend:
+    """Build a default-configured FakeBackend with two canned segments.
+
+    Two segments (rather than one) exercise the multi-yield path through
+    :meth:`WhisperBackend.transcribe`; the start values are
+    non-decreasing so invariant I3 has a default-pass case for the
+    silence / arbitrary-PCM tests that don't override the fake's
+    canned data.
+    """
+    from podcast_script.backends.base import TranscribedSegment
+
+    backend = FakeBackend(
+        canned=[
+            TranscribedSegment(start=0.0, end=1.5, text="hola"),
+            TranscribedSegment(start=1.5, end=3.0, text="qué tal"),
+        ],
+    )
+    backend.load(model="fake-tiny", device="cpu")
+    return backend
+
+
+def _faster_backend_factory() -> WhisperBackend:
+    from podcast_script.backends.faster import FasterWhisperBackend
+
+    backend = FasterWhisperBackend()
+    backend.load(model=_FASTER_TINY_MODEL, device=_REAL_DEVICE)
+    return backend
+
+
+def _mlx_backend_factory() -> WhisperBackend:
+    from podcast_script.backends.mlx import MlxWhisperBackend
+
+    backend = MlxWhisperBackend()
+    backend.load(model=_MLX_TINY_MODEL, device=_REAL_DEVICE)
+    return backend
+
+
+def _backend_params() -> list[object]:
+    """Build the parametrization list, skipping real backends on ImportError.
+
+    ``importlib.util.find_spec`` is the cheap probe — it does not import
+    the heavy library, just checks installability. Real-backend params
+    carry ``pytest.mark.skip`` reasons that name the missing dep so the
+    skip output points the developer at the fix.
+    """
+    params: list[object] = [
+        pytest.param(_fake_backend_factory, id="fake-whisper"),
+    ]
+
+    if importlib.util.find_spec("faster_whisper") is not None:
+        params.append(pytest.param(_faster_backend_factory, id="faster-whisper"))
+    else:
+        params.append(
+            pytest.param(
+                _faster_backend_factory,
+                id="faster-whisper",
+                marks=pytest.mark.skip(reason="faster_whisper not importable"),
+            )
+        )
+
+    if importlib.util.find_spec("mlx_whisper") is not None:
+        params.append(pytest.param(_mlx_backend_factory, id="mlx-whisper"))
+    else:
+        params.append(
+            pytest.param(
+                _mlx_backend_factory,
+                id="mlx-whisper",
+                marks=pytest.mark.skip(reason="mlx_whisper not importable"),
+            )
+        )
+
+    return params
+
+
+@pytest.fixture(params=_backend_params())
+def backend_factory(request: pytest.FixtureRequest) -> BackendFactory:
+    """Return a callable building one freshly-loaded backend per call.
+
+    Tests that need multiple instances (e.g. invariant I4 — repeatable
+    transcribe across calls on a single instance) call the factory
+    once; tests that need a fresh instance per assertion call it again.
+    The fixture is parametrized at the function level — each test runs
+    once per backend in :func:`_backend_params`.
+    """
+    factory: BackendFactory = request.param
+    return factory

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -26,6 +26,7 @@ from tests.fakes.whisper import FakeBackend
 
 BackendFactory = Callable[[], WhisperBackend]
 FailingBackendFactory = Callable[[BaseException], WhisperBackend]
+CacheMissBackendFactory = Callable[[float], WhisperBackend]
 
 _FASTER_TINY_MODEL = "tiny"
 # mlx-whisper expects a full HF repo ID — bare ``"tiny"`` 404s. The
@@ -206,4 +207,99 @@ def failing_backend_factory(request: pytest.FixtureRequest) -> FailingBackendFac
     surfaces this as :class:`ModelError`, never as the raw exception".
     """
     factory: FailingBackendFactory = request.param
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Synthetic cache-miss fixture (R-14 — first-run notice within 1 s)
+# ---------------------------------------------------------------------------
+
+
+def _cache_miss_fake_factory(build_delay_s: float) -> WhisperBackend:
+    return FakeBackend(cache_miss=True, load_delay_s=build_delay_s)
+
+
+def _cache_miss_faster_factory(build_delay_s: float) -> WhisperBackend:
+    """faster-whisper backend with synthetic cache miss + slow build.
+
+    Overrides ``_is_cached`` to ``False`` (forces the notice path) and
+    inserts ``build_delay_s`` of sleep inside ``_build_model`` so the
+    R-14 contract test can verify the notice fires BEFORE the slow
+    network/disk path — the production code path is the same wrap +
+    helper-call ordering inside :meth:`load`.
+    """
+    import time as _time
+
+    from podcast_script.backends.faster import FasterWhisperBackend
+
+    class _CacheMissFaster(FasterWhisperBackend):
+        def _is_cached(self, model: str) -> bool:
+            return False
+
+        def _build_model(self, model: str, device: str) -> object:
+            if build_delay_s > 0:
+                _time.sleep(build_delay_s)
+            return object()
+
+    return _CacheMissFaster()
+
+
+def _cache_miss_mlx_factory(build_delay_s: float) -> WhisperBackend:
+    """Mirror of ``_cache_miss_faster_factory`` for the mlx backend."""
+    import time as _time
+
+    from podcast_script.backends.mlx import MlxWhisperBackend
+
+    class _CacheMissMlx(MlxWhisperBackend):
+        def _is_cached(self, model: str) -> bool:
+            return False
+
+        def _build_model(self, model: str, device: str) -> object:
+            if build_delay_s > 0:
+                _time.sleep(build_delay_s)
+            return object()
+
+    return _CacheMissMlx()
+
+
+def _cache_miss_backend_params() -> list[object]:
+    params: list[object] = [
+        pytest.param(_cache_miss_fake_factory, id="fake-whisper"),
+    ]
+    if importlib.util.find_spec("faster_whisper") is not None:
+        params.append(pytest.param(_cache_miss_faster_factory, id="faster-whisper"))
+    else:
+        params.append(
+            pytest.param(
+                _cache_miss_faster_factory,
+                id="faster-whisper",
+                marks=pytest.mark.skip(reason="faster_whisper not importable"),
+            )
+        )
+    if importlib.util.find_spec("mlx_whisper") is not None:
+        params.append(pytest.param(_cache_miss_mlx_factory, id="mlx-whisper"))
+    else:
+        params.append(
+            pytest.param(
+                _cache_miss_mlx_factory,
+                id="mlx-whisper",
+                marks=pytest.mark.skip(reason="mlx_whisper not importable"),
+            )
+        )
+    return params
+
+
+@pytest.fixture(params=_cache_miss_backend_params())
+def cache_miss_backend_factory(
+    request: pytest.FixtureRequest,
+) -> CacheMissBackendFactory:
+    """Return a callable that builds a backend with a synthetic cache miss.
+
+    The caller passes a ``build_delay_s`` (seconds) which is the
+    artificial delay inserted inside ``_build_model`` to simulate a
+    slow HF download. The R-14 contract test passes a delay long
+    enough to demonstrate the notice fires BEFORE the slow part —
+    short enough to keep the suite quick.
+    """
+    factory: CacheMissBackendFactory = request.param
     return factory

--- a/tests/contract/test_first_run_notice.py
+++ b/tests/contract/test_first_run_notice.py
@@ -1,0 +1,152 @@
+"""Tier 2 contract test for the R-14 first-run-notice latency budget.
+
+The contract under test (POD-030, ADR-0017 §Tier 2; mitigation for
+PROJECT_PLAN §10.1 R-14): on a synthetic cache miss every backend's
+:meth:`load` MUST emit the locked ``event=model_download`` line
+**within 1 s** of ``load()`` entry, regardless of how slow the
+underlying ``huggingface_hub`` download path turns out to be on a
+given run. AC-US-5.1 states the requirement; ADR-0012 owns the line
+shape; NFR-6 sets the 1-s budget.
+
+The synthetic-cache-miss factory in :mod:`tests.contract.conftest`
+inserts an artificial delay inside ``_build_model`` so the test is
+meaningful: the notice's emission time is measured against the real
+clock from ``load()`` entry, and a backend that buried the notice
+behind the slow path would fail the budget.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+
+import pytest
+
+from tests.contract.conftest import CacheMissBackendFactory
+
+# Synthetic build delay — short enough to keep the suite quick, long
+# enough that the ordering check ("notice precedes build") has slack to
+# fail meaningfully. Bumped from 0.5 s so the helper-overhead margin
+# below leaves room for slower CI runners.
+_SYNTHETIC_BUILD_DELAY_S = 0.8
+
+# The R-14 / NFR-6 budget — also AC-US-5.1's "within 1 s of process start".
+_NOTICE_BUDGET_S = 1.0
+
+# Margin between "notice fired" and "build started". Empirically the
+# helper + lazy-import + monkeypatched-method dispatch settles in
+# < 100 ms on a modern laptop and < 200 ms on a cold GitHub Actions
+# runner. Used to set the strict ordering threshold below the synthetic
+# build delay so a backend that emits the notice after the slow path
+# fails the check even when total wall time stays under 1 s.
+_NOTICE_HELPER_OVERHEAD_S = 0.3
+
+
+def _capture_records() -> tuple[
+    logging.Handler,
+    list[logging.LogRecord],
+    Callable[[], None],
+]:
+    """Attach a model_download-only recording handler at the root logger.
+
+    Each backend writes its model_download record to its own module-level
+    logger (``podcast_script.backends.faster`` / ``…mlx`` for the real
+    backends, ``tests.fakes.whisper`` for FakeBackend). The CLI's
+    :func:`logging_setup.configure` is not in effect under pytest, so the
+    contributing loggers inherit their level from root — which defaults
+    to WARNING and would drop the INFO-level notice before propagation.
+
+    We bump root to INFO for the duration of the test, attach a filtering
+    handler that only records records with ``event=model_download`` (so
+    third-party INFO chatter from the real backends' lazy imports stays
+    out of the captured list), and return a teardown callable that
+    restores the previous level.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            if getattr(record, "event", None) == "model_download":
+                records.append(record)
+
+    root = logging.getLogger()
+    handler = _Capture()
+    handler.setLevel(logging.INFO)
+    root.addHandler(handler)
+    prior_level = root.level
+    if prior_level == logging.NOTSET or prior_level > logging.INFO:
+        root.setLevel(logging.INFO)
+
+    def _teardown() -> None:
+        root.removeHandler(handler)
+        root.setLevel(prior_level)
+
+    return handler, records, _teardown
+
+
+@pytest.mark.contract
+def test_first_run_notice_fires_within_one_second_of_load_entry(
+    cache_miss_backend_factory: CacheMissBackendFactory,
+) -> None:
+    """R-14 contract: notice's wall-clock emission MUST trail load()
+    entry by less than 1 s, even when the underlying build path takes
+    longer.
+
+    The synthetic ``_SYNTHETIC_BUILD_DELAY_S`` (0.5 s) sleep inside
+    ``_build_model`` simulates a slow HF download. A backend that
+    emitted the notice after ``_build_model`` returned would clock in
+    at ~0.5 s + helper overhead — the assertion below is engineered so
+    a regression of that shape is detectable within budget.
+    """
+    _handler, records, teardown = _capture_records()
+
+    backend = cache_miss_backend_factory(_SYNTHETIC_BUILD_DELAY_S)
+
+    t_start_wall = time.time()
+    try:
+        backend.load(model="tiny", device="cpu")
+    finally:
+        teardown()
+
+    notices = [r for r in records if getattr(r, "event", None) == "model_download"]
+    assert len(notices) == 1, (
+        f"AC-US-5.1: exactly one model_download record expected on a cache "
+        f"miss (got {len(notices)}: {[getattr(r, 'event', None) for r in records]})"
+    )
+    notice = notices[0]
+
+    elapsed_to_notice = notice.created - t_start_wall
+
+    # Formal R-14 / NFR-6 / AC-US-5.1 budget — the published 1-s contract.
+    assert elapsed_to_notice < _NOTICE_BUDGET_S, (
+        f"R-14 / NFR-6 / AC-US-5.1: model_download notice MUST fire within "
+        f"{_NOTICE_BUDGET_S} s of load() entry. Got {elapsed_to_notice:.3f} s "
+        f"with synthetic build delay of {_SYNTHETIC_BUILD_DELAY_S} s."
+    )
+
+    # Stricter assertion: the notice MUST precede the slow build path by
+    # a comfortable margin. This is what makes the synthetic build delay
+    # carry signal — a backend that emitted the notice AFTER `_build_model`
+    # returned would clock in at ~build_delay + helper overhead, failing
+    # this check even though it might still squeak under the formal 1-s
+    # budget for short delays. Mutation-tested locally by moving the
+    # `emit_first_run_notice_if_missing` call below the sleep in
+    # FakeBackend.load — the assertion catches it.
+    notice_must_precede_build_by = _SYNTHETIC_BUILD_DELAY_S - _NOTICE_HELPER_OVERHEAD_S
+    assert elapsed_to_notice < notice_must_precede_build_by, (
+        f"AC-US-5.1 ordering: model_download notice MUST fire BEFORE the "
+        f"slow build path (it is the user's signal that a multi-GB download "
+        f"is starting, not a post-hoc receipt). Synthetic build_delay was "
+        f"{_SYNTHETIC_BUILD_DELAY_S} s; notice fired {elapsed_to_notice:.3f} s "
+        f"in — should be < {notice_must_precede_build_by:.3f} s."
+    )
+
+    # Sanity: the synthetic build delay actually elapsed, so the
+    # ordering check above was meaningful (it had room to fail). If the
+    # backend short-circuits the build path, we lose the R-14 signal.
+    total_elapsed = time.time() - t_start_wall
+    assert total_elapsed >= _SYNTHETIC_BUILD_DELAY_S * 0.8, (
+        f"sanity: synthetic build_delay={_SYNTHETIC_BUILD_DELAY_S} s should "
+        f"make load() take roughly that long; got {total_elapsed:.3f} s"
+    )

--- a/tests/contract/test_whisper_protocol.py
+++ b/tests/contract/test_whisper_protocol.py
@@ -1,0 +1,55 @@
+"""Tier 2 contract tests for the WhisperBackend Protocol (POD-030).
+
+Each invariant runs against every backend in the parametrized
+``backend_factory`` fixture from :mod:`tests.contract.conftest` —
+``FakeBackend`` (always) plus each real backend whose library is
+importable on the current host. The same ``test_*`` function shape
+catches "the fake is no longer behaving like the real thing" drift
+that a fake-only Tier 1 suite is blind to (ADR-0017).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from podcast_script.backends.base import TranscribedSegment
+from tests.contract.conftest import BackendFactory
+
+SAMPLE_RATE = 16_000
+
+
+def _silence_pcm(duration_s: float) -> npt.NDArray[np.float32]:
+    """Generate ``duration_s`` of silence (zeros) at the project sample rate."""
+    return np.zeros(int(duration_s * SAMPLE_RATE), dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# I1 — empty PCM yields an empty Iterable without raising
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_transcribe_empty_pcm_yields_empty_iterable(
+    backend_factory: BackendFactory,
+) -> None:
+    """ADR-0017 Tier 2 invariant I1: ``transcribe(empty_pcm, lang)`` MUST
+    return an Iterable that produces zero items, without raising. The
+    pipeline (POD-008) feeds one speech segment at a time — a
+    zero-length speech segment (rare but legal — segmenter coalesces
+    near-zero-duration regions into noise) must not crash the run.
+
+    A backend that materialises ``pcm`` into a model call without an
+    early-return guard would either raise (numpy zero-shape -> lib
+    error) or silently emit a hallucinated transcript — both are
+    contract violations.
+    """
+    backend = backend_factory()
+    empty = np.zeros(0, dtype=np.float32)
+
+    result = list(backend.transcribe(empty, lang="es"))
+
+    assert result == []
+    for seg in result:
+        assert isinstance(seg, TranscribedSegment)

--- a/tests/contract/test_whisper_protocol.py
+++ b/tests/contract/test_whisper_protocol.py
@@ -17,7 +17,8 @@ import numpy.typing as npt
 import pytest
 
 from podcast_script.backends.base import TranscribedSegment
-from tests.contract.conftest import BackendFactory
+from podcast_script.errors import ModelError
+from tests.contract.conftest import BackendFactory, FailingBackendFactory
 
 SAMPLE_RATE = 16_000
 
@@ -146,3 +147,50 @@ def test_transcribe_is_repeatable_after_single_load(
 
     list(backend.transcribe(pcm, lang="es"))
     list(backend.transcribe(pcm, lang="es"))
+
+
+# ---------------------------------------------------------------------------
+# I5 — model-load failure surfaces as ModelError (not RuntimeError / ValueError)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_load_wraps_underlying_failure_as_model_error(
+    failing_backend_factory: FailingBackendFactory,
+) -> None:
+    """ADR-0017 Tier 2 invariant I5: when the underlying library reports
+    a load failure, every backend MUST raise :class:`ModelError`. The
+    cli's NFR-9 mapping translates ``ModelError`` to exit code 5
+    (ADR-0006); a raw ``RuntimeError`` or ``ConnectionError`` would
+    escape that contract and surface as the catch-all exit 1, breaking
+    the published shell-script contract (Risk #8).
+
+    The same mechanism covers AC-US-5.4 (network unreachable on first
+    run): all download / cache failures share the wrap.
+    """
+    failure = ConnectionError("Failed to resolve 'huggingface.co'")
+    backend = failing_backend_factory(failure)
+
+    with pytest.raises(ModelError) as exc_info:
+        backend.load(model="tiny", device="cpu")
+
+    assert exc_info.value.__cause__ is failure, (
+        "ModelError MUST chain the original exception via __cause__ for debuggability "
+        f"(got {exc_info.value.__cause__!r})"
+    )
+
+
+@pytest.mark.contract
+def test_load_does_not_swallow_keyboard_interrupt(
+    failing_backend_factory: FailingBackendFactory,
+) -> None:
+    """ADR-0014 / ADR-0017 corollary to I5: ``KeyboardInterrupt`` and
+    ``SystemExit`` MUST propagate untouched through ``load()`` even
+    though the broad ``Exception`` wrap is in place. Wrapping these
+    would mis-translate Ctrl-C to exit 5 instead of the standard 130;
+    AC-US-5.3 resume / restart is on the user, not us.
+    """
+    backend = failing_backend_factory(KeyboardInterrupt())
+
+    with pytest.raises(KeyboardInterrupt):
+        backend.load(model="tiny", device="cpu")

--- a/tests/contract/test_whisper_protocol.py
+++ b/tests/contract/test_whisper_protocol.py
@@ -10,6 +10,8 @@ that a fake-only Tier 1 suite is blind to (ADR-0017).
 
 from __future__ import annotations
 
+from itertools import pairwise
+
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -53,3 +55,94 @@ def test_transcribe_empty_pcm_yields_empty_iterable(
     assert result == []
     for seg in result:
         assert isinstance(seg, TranscribedSegment)
+
+
+# ---------------------------------------------------------------------------
+# I2 — silence PCM does not raise (yielding empty or zero-text is fine)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_transcribe_silence_does_not_raise(
+    backend_factory: BackendFactory,
+) -> None:
+    """ADR-0017 Tier 2 invariant I2: ``transcribe(silence_pcm, lang)``
+    MUST NOT raise. Real episodes routinely contain silent intros /
+    outros / inter-segment gaps; the segmenter (C-Segment) carves them
+    out as ``noise`` / ``silence`` regions which the renderer drops, but
+    short residual silent slices still reach the backend. A backend
+    that explodes on near-zero-variance input (z-score normalisation
+    inside whisper-class models is a known offender) would fail every
+    real run.
+
+    The contract permits either an empty Iterable or zero-text segments
+    — both are acceptable per ADR-0017. We only assert the absence of
+    an exception, and that any yielded items are well-typed.
+    """
+    backend = backend_factory()
+    silence = _silence_pcm(2.0)
+
+    out = list(backend.transcribe(silence, lang="es"))
+
+    for seg in out:
+        assert isinstance(seg, TranscribedSegment)
+
+
+# ---------------------------------------------------------------------------
+# I3 — yielded segment starts are non-decreasing within a single call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_transcribe_yields_non_decreasing_starts(
+    backend_factory: BackendFactory,
+) -> None:
+    """ADR-0017 Tier 2 invariant I3: within a single ``transcribe`` call
+    the yielded ``TranscribedSegment.start`` values MUST be
+    non-decreasing. The renderer (POD-011) interleaves speech with
+    music markers by absolute time and assumes monotonic ordering — an
+    out-of-order yield would produce a Markdown timeline that contradicts
+    itself.
+
+    Real backends produce monotonic output naturally (Whisper decoders
+    walk the audio left-to-right). The fake's :data:`_DEFAULT_CANNED`
+    is also monotonic; mutation-tested locally by reversing the canned
+    list — the assertion below catches the regression.
+    """
+    backend = backend_factory()
+    pcm = _silence_pcm(3.0)
+
+    starts = [seg.start for seg in backend.transcribe(pcm, lang="es")]
+
+    for prev, nxt in pairwise(starts):
+        assert prev <= nxt, (
+            f"non-decreasing-start invariant violated: {prev} > {nxt} in sequence {starts}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# I4 — transcribe is callable repeatedly on the same instance after load()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_transcribe_is_repeatable_after_single_load(
+    backend_factory: BackendFactory,
+) -> None:
+    """ADR-0017 Tier 2 invariant I4: a single backend instance MUST
+    accept multiple ``transcribe`` calls after one ``load`` call. The
+    Pipeline (POD-008) iterates the segmenter's speech regions and
+    invokes ``transcribe`` once per region per ADR-0004's streaming
+    contract; if a backend turned single-use after the first call, an
+    episode with two speech segments would fail on the second.
+
+    Implicit single-use state would manifest as either a raised
+    exception on the second call or a silently-empty result. We assert
+    the call **completes** (the result may legally be empty for silence
+    inputs per I2) and that no exception escapes.
+    """
+    backend = backend_factory()
+    pcm = _silence_pcm(1.5)
+
+    list(backend.transcribe(pcm, lang="es"))
+    list(backend.transcribe(pcm, lang="es"))

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -1,0 +1,6 @@
+"""Reusable test doubles (POD-030).
+
+Lives outside :mod:`tests.contract` and :mod:`tests.unit` so Tier 1
+tests can adopt the same fakes once POD-029's reorganisation lands —
+keeping a single canonical FakeBackend prevents fake-vs-fake drift.
+"""

--- a/tests/fakes/whisper.py
+++ b/tests/fakes/whisper.py
@@ -33,14 +33,28 @@ class FakeBackend:
         self,
         *,
         canned: Sequence[TranscribedSegment] | None = None,
+        load_failure: BaseException | None = None,
     ) -> None:
         self._canned: tuple[TranscribedSegment, ...] = (
             tuple(canned) if canned is not None else _DEFAULT_CANNED
         )
+        self._load_failure = load_failure
         self._loaded = False
 
     def load(self, model: str, device: str) -> None:
-        del model, device
+        del device
+        if self._loaded:
+            return
+        if self._load_failure is not None:
+            failure = self._load_failure
+            try:
+                raise failure
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except Exception as e:
+                raise ModelError(
+                    f"Failed to load fake-whisper model '{model}': {type(e).__name__}: {e}"
+                ) from e
         self._loaded = True
 
     def transcribe(

--- a/tests/fakes/whisper.py
+++ b/tests/fakes/whisper.py
@@ -49,12 +49,14 @@ class FakeBackend:
         lang: str,
         sample_rate: int = 16000,
     ) -> Iterator[TranscribedSegment]:
-        del pcm, lang, sample_rate
+        del lang, sample_rate
         if not self._loaded:
             raise ModelError(
                 "FakeBackend.transcribe() called before load(); "
                 "the orchestrator must call load() first per ADR-0009."
             )
+        if pcm.size == 0:
+            return iter(())
         return iter(self._canned)
 
 

--- a/tests/fakes/whisper.py
+++ b/tests/fakes/whisper.py
@@ -10,13 +10,20 @@ test-only fake and any future reimplementation.
 
 from __future__ import annotations
 
+import logging
+import time
 from collections.abc import Iterator, Sequence
 
 import numpy as np
 import numpy.typing as npt
 
-from podcast_script.backends.base import TranscribedSegment
+from podcast_script.backends.base import (
+    TranscribedSegment,
+    emit_first_run_notice_if_missing,
+)
 from podcast_script.errors import ModelError
+
+_log = logging.getLogger(__name__)
 
 _DEFAULT_CANNED: tuple[TranscribedSegment, ...] = (
     TranscribedSegment(start=0.0, end=1.5, text="hola"),
@@ -34,17 +41,27 @@ class FakeBackend:
         *,
         canned: Sequence[TranscribedSegment] | None = None,
         load_failure: BaseException | None = None,
+        cache_miss: bool = False,
+        load_delay_s: float = 0.0,
     ) -> None:
         self._canned: tuple[TranscribedSegment, ...] = (
             tuple(canned) if canned is not None else _DEFAULT_CANNED
         )
         self._load_failure = load_failure
+        self._cache_miss = cache_miss
+        self._load_delay_s = load_delay_s
         self._loaded = False
 
     def load(self, model: str, device: str) -> None:
         del device
         if self._loaded:
             return
+        if self._cache_miss:
+            emit_first_run_notice_if_missing(
+                model,
+                is_cached=lambda _m: False,
+                logger=_log,
+            )
         if self._load_failure is not None:
             failure = self._load_failure
             try:
@@ -55,6 +72,8 @@ class FakeBackend:
                 raise ModelError(
                     f"Failed to load fake-whisper model '{model}': {type(e).__name__}: {e}"
                 ) from e
+        if self._load_delay_s > 0:
+            time.sleep(self._load_delay_s)
         self._loaded = True
 
     def transcribe(

--- a/tests/fakes/whisper.py
+++ b/tests/fakes/whisper.py
@@ -1,0 +1,61 @@
+"""``FakeBackend`` — reusable test double for :class:`WhisperBackend` (POD-030).
+
+Implements the ADR-0003 Protocol with no heavy library imports so Tier 2
+contract tests can compare its behaviour against the real backends
+without paying any cold-import cost. The same class is the "F" in the
+parametrized ``[FakeBackend, FasterWhisperBackend, MlxWhisperBackend]``
+contract suite — keeping it single-source prevents drift between the
+test-only fake and any future reimplementation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+from podcast_script.backends.base import TranscribedSegment
+from podcast_script.errors import ModelError
+
+_DEFAULT_CANNED: tuple[TranscribedSegment, ...] = (
+    TranscribedSegment(start=0.0, end=1.5, text="hola"),
+    TranscribedSegment(start=1.5, end=3.0, text="qué tal"),
+)
+
+
+class FakeBackend:
+    """In-memory :class:`WhisperBackend` for the contract suite."""
+
+    name = "fake-whisper"
+
+    def __init__(
+        self,
+        *,
+        canned: Sequence[TranscribedSegment] | None = None,
+    ) -> None:
+        self._canned: tuple[TranscribedSegment, ...] = (
+            tuple(canned) if canned is not None else _DEFAULT_CANNED
+        )
+        self._loaded = False
+
+    def load(self, model: str, device: str) -> None:
+        del model, device
+        self._loaded = True
+
+    def transcribe(
+        self,
+        pcm: npt.NDArray[np.float32],
+        lang: str,
+        sample_rate: int = 16000,
+    ) -> Iterator[TranscribedSegment]:
+        del pcm, lang, sample_rate
+        if not self._loaded:
+            raise ModelError(
+                "FakeBackend.transcribe() called before load(); "
+                "the orchestrator must call load() first per ADR-0009."
+            )
+        return iter(self._canned)
+
+
+__all__ = ["FakeBackend"]


### PR DESCRIPTION
## Summary
- Adds the ADR-0017 Tier 2 contract suite under `tests/contract/`: five
  `WhisperBackend` Protocol invariants run identically against
  `FakeBackend` and each importable real backend
  (`FasterWhisperBackend`, `MlxWhisperBackend`).
- Adds the R-14 first-run-notice latency contract — synthetic-cache-miss
  `load()` MUST emit `event=model_download` within 1 s **and** before
  the slow build path (the ordering check is what makes it
  load-bearing; the formal 1-s budget alone misses notice-after-build
  regressions).
- Reusable `FakeBackend` lives at `tests/fakes/whisper.py` so a future
  POD-029 reorganisation of Tier 1 can adopt it without drift.
- Closes POD-030 (sprint SP-6 of `PROJECT_PLAN.md`).

## ADR-0017 Tier 2 invariants asserted
- [x] I1 — `transcribe(empty_pcm, lang)` yields an empty Iterable.
- [x] I2 — `transcribe(silence_pcm, lang)` does not raise.
- [x] I3 — yielded `TranscribedSegment.start` values are non-decreasing.
- [x] I4 — `transcribe()` is repeatable on a single instance after one `load()`.
- [x] I5 — underlying load failure wraps as `ModelError` (with `KeyboardInterrupt` propagating per ADR-0014).
- [x] R-14 — synthetic cache-miss notice fires within 1 s of `load()` and BEFORE the slow build path.

## Mutation testing (POD-032 pattern)
Each invariant was verified locally by deliberately breaking the fake:
- raise on silence input → fails I2 + I3 + I4
- reverse canned segments → fails I3 alone (surgical)
- single-use flag flipping → fails I4 alone
- emit notice after the slow path → fails R-14 ordering check

## Risks touched
- **R-14** (huggingface_hub 1-s notice): mitigated. Synthetic-cache-miss
  factory drives the contract without network traffic; ordering check
  guarantees the notice precedes the slow path.
- **R-17** (faster-whisper / mlx-whisper API drift): I5's broad
  `except Exception` wrap test reinforces the existing Tier 1 coverage
  at the contract layer.

## Documentation updated
- [x] `CHANGELOG.md` `[Unreleased]` / Test fixtures + quality gates (PR #TBD placeholder; replaced post-open).
- [x] `README.md` Development section: reflects the actual marker boundaries (Tier 2 is `pytest.mark.contract`, opt in via `pytest -m contract`).

## CI changes
- `.github/workflows/ci.yml`: adds a discrete `pytest -m contract -v`
  step on the Ubuntu + macOS-14 matrix per ADR-0017. Skip-on-ImportError
  per ADR-0011 keeps Ubuntu green even though `mlx_whisper` is excluded
  from `uv sync` there (PEP 508 marker is darwin/arm64 only).

## Test plan
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy` — clean (41 source files)
- [x] `uv run pytest` — 252 passed (default Tier 1)
- [x] `uv run pytest -m contract` — 21 passed (new Tier 2)
- [x] `uv run pytest --cov=podcast_script.segment --cov-fail-under=100 tests/test_segment.py tests/test_segment_property.py` — 100% coverage
- [ ] CI green on Ubuntu + macOS-14 matrix (verified post-push)

## Follow-up (out of scope; logged in `.task/POD-030.md`)
- `MlxWhisperBackend._build_model` passes the raw user-supplied `--model tiny` to `mlx_whisper.load_models.load_model`, which expects a full HF repo ID (`mlx-community/whisper-tiny`); the sibling `_is_cached` already encodes the convention. Worked around in the contract fixture; real fix is a US-5 bug to track separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)