### PR TITLE
docs(POD-029): fix stale tests/test_* refs in git mv'd modules

### DIFF
--- a/tests/integration/test_integration_ec3.py
+++ b/tests/integration/test_integration_ec3.py
@@ -7,10 +7,10 @@ EC-3 (SRS §7) is the documented edge case "user passes
 load-bearing implementation choice is :func:`subprocess.run` invoked
 with a list of arguments rather than a shell string, locked in
 ``decode.py`` (POD-007 / R-4 / SYSTEM_DESIGN §5.6). Tier 1 coverage
-already exists at ``tests/test_decode.py::test_decode_handles_path_with_
-spaces_and_non_ascii_EC_3`` and ``tests/test_cli.py::test_quoted_value_
-with_special_chars_round_trips``; this module adds the missing **Tier 3
-end-to-end** layer per ADR-0017 — real ffmpeg decode, real
+already exists at ``tests/unit/test_decode.py::test_decode_handles_path_
+with_spaces_and_non_ascii_EC_3`` and ``tests/unit/test_cli.py::test_quoted
+_value_with_special_chars_round_trips``; this module adds the missing
+**Tier 3 end-to-end** layer per ADR-0017 — real ffmpeg decode, real
 ``faster-whisper`` tiny transcribe, real Markdown render, real atomic
 write — on the EC-3 path.
 
@@ -188,7 +188,7 @@ def test_cli_round_trips_ec_3_path_with_spaces_and_non_ascii(
 # ---------------------------------------------------------------------------
 
 # POD-033 — same logfmt grammar as locked in
-# ``tests/test_cli.py::TestNFR10LogfmtRegex._PAIR``.
+# ``tests/unit/test_cli.py::TestNFR10LogfmtRegex._PAIR``.
 _LOGFMT_PAIR = r'[A-Za-z_][A-Za-z0-9_]*=(?:"(?:[^"\\]|\\.)*"|[^\s="]+)'
 _LOGFMT_LINE_RE = re.compile(rf"^{_LOGFMT_PAIR}(?: {_LOGFMT_PAIR})*$")
 

--- a/tests/integration/test_integration_tiny.py
+++ b/tests/integration/test_integration_tiny.py
@@ -261,7 +261,7 @@ def _assert_same_structure(actual: str, reference: str) -> None:
 
 
 # POD-033 — same logfmt grammar as locked in
-# ``tests/test_cli.py::TestNFR10LogfmtRegex._PAIR``. Duplicated as a
+# ``tests/unit/test_cli.py::TestNFR10LogfmtRegex._PAIR``. Duplicated as a
 # free function here rather than imported across test modules so each
 # tier reads top-down without a shared helper file.
 _LOGFMT_PAIR = r'[A-Za-z_][A-Za-z0-9_]*=(?:"(?:[^"\\]|\\.)*"|[^\s="]+)'

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -443,7 +443,7 @@ class TestForceOverwrite:
 
     The pipeline is monkeypatched to keep these tests in the cli's
     Tier-1 boundary (no ffmpeg, no model). The unit-level atomic_write
-    invariants are covered separately in ``tests/test_atomic_write.py``.
+    invariants are covered separately in ``tests/unit/test_atomic_write.py``.
     """
 
     def test_force_actually_replaces_existing_output_AC_US_6_2(
@@ -671,7 +671,7 @@ class TestEventCatalogue:
     The catalogue is the implicit grep contract for shell scripts wrapping
     the tool (SRS Risk #9). These tests lock the four lifecycle tokens
     that depend on cli orchestration; the phase-boundary tokens are
-    covered by ``tests/test_pipeline.py``.
+    covered by ``tests/unit/test_pipeline.py``.
     """
 
     def _events_in(self, stderr: str) -> list[str]:

--- a/tests/unit/test_segment_property.py
+++ b/tests/unit/test_segment_property.py
@@ -9,7 +9,7 @@ segment list MUST account for every second of input regardless).
 
 ADR-0017 §"Property-based testing throughout" explicitly green-lights
 ``hypothesis`` as the Tier-2 enhancement on top of the hand-written
-invariants in ``tests/test_segment.py``. The strategies here generate
+invariants in ``tests/unit/test_segment.py``. The strategies here generate
 the full space of *valid* raw segmenter outputs — sorted-or-not,
 disjoint, label-in-known-vocabulary — because the production wrapper's
 ModelError guards (overlap / unknown label) push those failure paths
@@ -20,8 +20,8 @@ than NFR-3 / NFR-4.
 NFR-8 100% line coverage gate on the segment-merge surface
 (``_normalize_to_segments``, ``to_jsonl``, ``Segment``) is enforced by a
 discrete CI step (see ``.github/workflows/ci.yml``); these property
-tests + the example tests in ``test_segment.py`` together pin the lines
-that matter.
+tests + the example tests in ``tests/unit/test_segment.py`` together pin
+the lines that matter.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Follow-up to PR #30 review. Six stale `tests/test_*` cross-references survived `git mv similarity 100%` inside docstrings + comments of moved files; each rewritten to the new `tests/unit/` or `tests/integration/` path.
- Pure documentation fix — no test renamed, no assertion touched, no source code modified.

## Acceptance criteria satisfied
- [x] All six occurrences flagged in PR #30 review fixed (plus one adjacent hit in the same paragraph: a second `test_segment.py` reference at `tests/unit/test_segment_property.py:23` that would have left a half-stale docstring if ignored).
- [x] `grep -rn 'tests/test_' tests/ src/` returns zero matches in tracked source.
- [x] Default suite byte-identical to post-#30 baseline: 252 passed in 1.50 s.
- [x] `ruff check` / `ruff format --check` / `mypy --strict` clean (43 files).

## Files touched
| file | hits |
| --- | --- |
| `tests/unit/test_segment_property.py` | 2 (lines 12 + 23 — both `test_segment.py`) |
| `tests/unit/test_cli.py` | 2 (`atomic_write` @ 446, `pipeline` @ 674) |
| `tests/integration/test_integration_ec3.py` | 2 (wrapped `test_decode.py` / `test_cli.py` block @ 10–11, `TestNFR10LogfmtRegex._PAIR` @ 191) |
| `tests/integration/test_integration_tiny.py` | 1 (`TestNFR10LogfmtRegex._PAIR` @ 264) |

## Risks touched
None. Pure docstring/comment text — pytest doesn't read these strings; ruff + mypy don't care.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` / `mypy --strict` → clean.
- [x] `uv run pytest -q` → 252 passed (unchanged from post-#30 baseline).
- [ ] CI matrix: expected green; the diff is text-inside-docstrings only.

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target.
- [x] No code change → no AC re-verification needed.
- [x] No CHANGELOG entry needed (a docstring-only follow-up to a previous CHANGELOG'd PR doesn't warrant its own bullet — the post-merge state matches what `[Unreleased] ### Changed` already describes).

Refs PR #30 review (suggestion bucket), POD-029, ADR-0017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)