### PR TITLE
docs(POD-037): docs/ARCHITECTURE.md — four-bullet one-pager (SRS §16.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,18 @@ major-version bump per SemVer.
 - `LICENSE` (MIT) at the repo root; `[project] license = "MIT"` +
   `license-files = ["LICENSE"]` in `pyproject.toml` per PEP 639
   (PR #23 review-fix).
+- `docs/ARCHITECTURE.md` — the maintainer-facing front-door
+  one-pager mandated by SRS §16.2 / Q20. Covers exactly the four
+  load-bearing invariants (segment-then-transcribe pipeline;
+  `WhisperBackend` Protocol + platform-detection rule;
+  segmenter-covers / renderer-drops noise + silence;
+  atomic-write via temp + rename) with each bullet naming the
+  failure mode the choice avoids and pointing at the relevant
+  ADR. No "rejected alternatives" appendix per SRS §1.3 Won't
+  list — that material stays in the individual ADRs under
+  `docs/adr/`. 176 lines; the rest of v1 maintainer-facing docs
+  surface (README, CHANGELOG, ADRs) is already in place
+  (PR #TBD / POD-037).
 
 #### Test fixtures + quality gates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@ major-version bump per SemVer.
   list — that material stays in the individual ADRs under
   `docs/adr/`. 176 lines; the rest of v1 maintainer-facing docs
   surface (README, CHANGELOG, ADRs) is already in place
-  (PR #TBD / POD-037).
+  (PR #37 / POD-037).
 
 #### Test fixtures + quality gates
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,176 @@
+# Architecture
+
+This is the four-bullet front door to the design. Each bullet names
+the choice, the failure mode it avoids, and the ADR with the deeper
+"why". Read top-to-bottom in five minutes; dig into the linked ADRs
+when you need the alternatives-considered detail.
+
+The four topics here are the ones `SRS.md` §16.2 fixes for v1.0;
+nothing else belongs in this file. Per `SRS.md` §1.3, an
+ADR-style "rejected alternatives" appendix is explicitly **out of
+scope** for v1 — that material lives in the individual ADRs under
+[`docs/adr/`](adr/).
+
+---
+
+## 1. Segment first, transcribe only the speech
+
+The pipeline runs `inaSpeechSegmenter` over the decoded PCM **before**
+any Whisper call, labels every second of audio as one of
+`{speech, music, noise, silence}`, and feeds **only the speech
+segments** through Whisper. Music regions become English markers in
+the output Markdown (`> [MM:SS — music starts]` / `> [MM:SS — music
+ends]`); noise and silence regions are dropped at render time
+(see §3).
+
+**The failure mode this avoids:** Whisper is a speech model, trained
+on speech. On music it doesn't politely refuse — it hallucinates
+plausible-but-fake "lyrics" with full confidence, sometimes for
+minutes at a stretch. Running Whisper on the whole file (the simpler
+two-step "decode → transcribe" pipeline) produces a transcript with
+fabricated speech interleaved through every musical segment, and the
+listener has no way to tell which lines are real. Segmenting first
+is the only way to keep Whisper away from the inputs it's wrong on.
+
+The orchestrator is a pipes-and-filters `Pipeline` class
+(`src/podcast_script/pipeline.py`) with constructor-injected stages,
+streaming one transcribe call per speech segment so a mid-loop
+failure leaves the partial transcript usable in `--debug` artefacts.
+
+**See also:** [ADR-0002](adr/0002-pipes-and-filters-pipeline.md)
+(pipeline shape), [ADR-0004](adr/0004-streaming-per-segment-transcribe.md)
+(per-segment streaming contract),
+[ADR-0010](adr/0010-pipeline-level-progress-tick.md) (where the
+`rich` progress bar ticks).
+
+---
+
+## 2. Two backends, one Protocol, one composition root
+
+The transcribe step is fronted by a `WhisperBackend` Protocol
+(`src/podcast_script/backends/base.py`) with two concrete
+implementations: `FasterWhisperBackend` (CPU / Linux / Intel macOS)
+and `MlxWhisperBackend` (Apple Silicon). `select_backend()` reads
+`sys.platform` + `platform.machine()` and picks `mlx-whisper` for
+`arm64-darwin`, else `faster-whisper`. `--backend faster-whisper`
+always wins; `--backend mlx-whisper` off Apple Silicon raises
+`UsageError` (exit 2) per UC-1 E7.
+
+**The failure mode this avoids:** hard-coding either backend ties the
+tool to one platform. `mlx-whisper` is the only path that uses Apple
+Silicon's Neural Engine — without it, Apple Silicon users get
+nothing better than CPU `faster-whisper`. `mlx-whisper` is also a
+Darwin/arm64-only wheel (PEP 508 marker in `pyproject.toml`); a
+hard-import would break `uv sync` on Linux. The Protocol abstraction
+is also the testability seam ADR-0017's three-tier strategy depends
+on — Tier 1 unit tests inject a `FakeBackend` and never load
+`faster-whisper` or `mlx-whisper`.
+
+Both real backends use lazy imports inside `load()` so a Tier 1
+`pytest` run boots in <1 s without either heavy dep installed
+(per [ADR-0011](adr/0011-lazy-imports-for-heavy-deps.md)). The
+Protocol's behavioural invariants are pinned by Tier 2 contract
+tests (`tests/contract/`) running identically against `FakeBackend`
+and each importable real backend.
+
+**See also:** [ADR-0003](adr/0003-whisper-backend-protocol.md)
+(Protocol + platform rule), [ADR-0011](adr/0011-lazy-imports-for-heavy-deps.md)
+(lazy-import boundary), [ADR-0017](adr/0017-three-tier-test-strategy.md)
+(why the Protocol is the testability seam).
+
+---
+
+## 3. Segmenter covers every second; renderer drops two of four labels
+
+The segment-merge module (`src/podcast_script/segment.py`) emits a
+list of `Segment(start, end, label)` records that **cover every
+second** of the input — gaps are filled with synthetic `silence`
+segments, and the four-label vocabulary
+(`speech` / `music` / `noise` / `silence`) is the only thing
+downstream code accepts (NFR-3 ordering, NFR-4 coverage; pinned by
+property tests in `tests/unit/test_segment_property.py`). The
+renderer (`src/podcast_script/render.py`, the `_emit_segment` branch
+near line 100) then **drops** `noise` and `silence` regions: they
+exist in the structured layer (`segments.jsonl` under `--debug`)
+but produce no lines in the user-facing Markdown.
+
+**The failure mode this avoids:** without segmenter coverage, music
+or non-speech regions slip through unannotated and Whisper sees them
+(see §1's hallucination failure). Without the renderer drop, the
+Markdown would be cluttered with `> [MM:SS — silence starts]` lines
+between every utterance — not what podcast producers (the v1 actor
+per `SRS.md` §3) want to read or re-publish. Splitting "must
+classify" (segmenter responsibility, NFR-4) from "must render"
+(renderer responsibility, AC-US-2.5) keeps each layer simple: the
+segmenter doesn't decide visibility, the renderer doesn't decide
+classification.
+
+The split also keeps `--debug`'s `segments.jsonl` lossless: a
+maintainer reproducing a bug can inspect the full noise/silence
+classification, even though the user-facing Markdown drops them.
+
+**See also:** `SRS.md` AC-US-2.5 (renderer drop) + NFR-4 (segmenter
+coverage) + §Q7 (the resolved decision); `tests/unit/test_segment.py`
++ `tests/unit/test_segment_property.py` (the invariants pinned in
+code). No ADR — this is a pure rendering policy decision recorded
+in the SRS, not an architectural choice with structural alternatives.
+
+---
+
+## 4. All-or-nothing output via temp file + atomic rename
+
+The final Markdown lands at the resolved output path via
+`atomic_write()` (`src/podcast_script/atomic_write.py`). The helper
+opens a tempfile in the **same directory** as the target
+(`tempfile.NamedTemporaryFile(dir=path.parent, …, delete=False)`),
+writes the full payload, `fsync`s the file, then calls
+`os.replace(tmp_path, path)`. POSIX `rename(2)` is atomic on the
+same filesystem (NFR-5 contract). On any failure before the
+`os.replace`, the tempfile is unlinked in `finally`; any prior
+`episode.md` at the target path is untouched (AC-US-6.3).
+
+**The failure mode this avoids:** a non-atomic write — say, opening
+the target path directly with `"w"` mode — leaves a partial Markdown
+file at the resolved output path on any mid-run failure (SIGTERM,
+OOM, decode crash, transcribe error). Subsequent re-runs would then
+hit AC-US-6.1's refuse-overwrite gate without `--force` and the user
+is locked out by their own broken file. Worse, the partial file
+*looks* finished to a casual reader: there's no marker for
+"transcription was interrupted at minute 12 of 47". Atomic rename
+ensures the only two observable states are "no output" and "complete
+output" — never "partial output that looks complete".
+
+The contract is exercised at three test tiers: Tier 1 in
+`tests/unit/test_atomic_write.py` (in-process exception cleanup),
+Tier 2 nothing specific (the helper has no Protocol surface),
+and Tier 3 in `tests/integration/test_failure_injection.py`
+(POD-034 — spawns the CLI as a real subprocess, SIGTERMs it
+mid-transcribe, asserts no output landed and no `*.tmp` debris
+survives). Together those pin the design rather than just the
+implementation: any refactor that opened a tempfile during
+transcribe (rather than near the end of `Pipeline.run`) would fail
+the Tier 3 `*.tmp`-debris assertion.
+
+**See also:** [ADR-0005](adr/0005-atomic-output-via-temp-and-rename.md)
+(decision + alternatives); `SRS.md` NFR-5 (the contract this honours)
++ AC-US-6.3 (the user-visible AC); POD-009 (implementation),
+POD-034 (failure-injection test).
+
+---
+
+## Pointers for further reading
+
+- **Module layout:** `src/podcast_script/` — see
+  [ADR-0007](adr/0007-flat-src-package-layout.md) for the decision
+  log, `SYSTEM_DESIGN.md` §3.1 for the current map.
+- **All ADRs:** `docs/adr/` — 17 accepted ADRs as of v1.0; the
+  index is in [`docs/adr/README.md`](adr/README.md).
+- **Test strategy:** [ADR-0017](adr/0017-three-tier-test-strategy.md)
+  + `tests/{unit,contract,integration}/` (the shape was finalised
+  in POD-029).
+- **Error → exit-code mapping:**
+  [ADR-0006](adr/0006-error-to-exit-code-via-typed-exceptions.md);
+  user-visible table is in `README.md` "Exit codes".
+- **Locked log-event catalogue:**
+  [ADR-0012](adr/0012-event-catalogue-freeze.md); the 22 tokens are
+  the SemVer-tracked grep contract from v1.0 onwards.


### PR DESCRIPTION
## Summary
- New `docs/ARCHITECTURE.md` — the maintainer-facing front door mandated by `SRS.md` §16.2 / Q20. Covers exactly the four load-bearing invariants the SRS fixes; nothing else.
- Closes **POD-037** (lowest-ID open task in SP-8).
- Pure prose. No source / test / config touched.

## Acceptance criteria satisfied
- [x] **AC-1** — `docs/ARCHITECTURE.md` exists at the path SRS §16.2 mandates.
- [x] **AC-2** — Covers exactly the four topics from `SRS.md:544-547`, in order:
  1. Segment-then-transcribe pipeline + why (avoids Whisper hallucinations on music).
  2. `WhisperBackend` Protocol + platform-detection rule (`arm64-darwin` → mlx-whisper, else faster-whisper).
  3. Noise/silence renderer-filter rationale (segmenter covers, renderer drops).
  4. Atomic-write rationale (write-temp-then-rename preserves prior `episode.md` on failure).
- [x] **AC-3** — Each bullet has an explicit "**The failure mode this avoids**" paragraph naming a concrete failure shape (matches the SRS's "why this exists" framing — not "it's nicer this way").
- [x] **AC-4** — Each bullet ends with a "**See also**" footer pointing at the relevant ADR + SRS sections; for §3 (no ADR; pure rendering policy) it points at SRS Q7 / AC-US-2.5 / NFR-4 + the property tests pinning the invariants in code.
- [x] **AC-5** — No "rejected alternatives" appendix (`SRS.md` §1.3 Won't-list, line 483; Q20 deferred this from v1).
- [x] **AC-6** — 176 lines total; reads as the front door, not a duplicate of the ADR set. Fits the SRS's "one-page note" framing.

## Edge cases covered
- [x] **All 11 ADR cross-references resolve** — verified each `adr/000N-*.md` and `adr/README.md` link points at an existing file.
- [x] **No scope creep into ADR territory** — each bullet is one short paragraph + failure-mode + see-also; deeper context lives in the linked ADRs (so the doc doesn't drift when an ADR's "Consequences" section evolves).
- [x] **§3's missing ADR handled honestly** — the noise/silence drop is a rendering policy from SRS Q7, not an architectural decision with structural alternatives. The doc says so explicitly and points at SRS sections + property tests rather than fabricating an ADR.
- [x] **§4 references both halves of its test coverage** — Tier 1 unit tests for in-process exception cleanup + Tier 3 POD-034 failure-injection for SIGTERM-mid-transcribe. Together those pin the *design* (any refactor that opened a tempfile during transcribe would fail Tier 3's `*.tmp`-debris assertion).

## Risks touched
- **Maintainer bus-factor** (`PROJECT_PLAN.md:436`) — names ARCHITECTURE.md as a load-bearing piece of the "anyone forking can pick it up" mitigation. This PR delivers the named piece.

## Documentation updated
- [x] `docs/ARCHITECTURE.md` — new file, 176 lines, four numbered sections + a closing "Pointers for further reading" index.
- [x] `CHANGELOG.md` `[Unreleased] ### Added > #### Documentation` — entry naming the four covered topics, the failure-mode framing, and the §1.3 Won't-list compliance.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` / `mypy --strict` — clean (44 files; no source touched).
- [x] `uv run pytest -q` — 252 passed (Tier 1 unaffected).
- [x] All 11 internal cross-links resolve (manual sweep — `for f in ...; do test -f docs/$f; done`).
- [x] `wc -l docs/ARCHITECTURE.md` → 176 (within "one-page note" envelope).
- [x] `grep -c "^## [1-4]\." docs/ARCHITECTURE.md` → 4 (exactly the SRS-mandated topic count, no stray section).
- [ ] CI matrix (Ubuntu + macOS-14): expected green; doc-only diff.

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target.
- [x] No code change → no AC re-verification needed.
- [x] CHANGELOG `[Unreleased] ### Added > #### Documentation` updated.
- [x] Story status: POD-037 finished.
- [ ] CI matrix box (filled post-merge).
- [ ] Maintainer signoff at sprint review (per `PROJECT_PLAN.md` §1.5).

Refs POD-037, SRS §16.2, SRS Q20, SRS §1.3 Won't-list, PROJECT_BRIEF.md §15, PROJECT_PLAN.md §10 R-9 mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)