### PR TITLE
chore: pin v1.0 surface — dep major-caps (R-14, R-17) + ubuntu-24.04 runner (R-13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        # Pinned images (no ``-latest``) so a runner-image rollover can't
+        # break CI silently. ``macos-14`` was already pinned per
+        # PROJECT_PLAN.md §10 R-13 mitigation; ``ubuntu-24.04`` applies
+        # the same risk shape to the Linux runner and mirrors the pin in
+        # ``pip-audit.yml`` (PR #33). Bump both deliberately when a new
+        # GitHub-hosted image is desired.
+        os: [ubuntu-24.04, macos-14]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,25 @@ major-version bump per SemVer.
   preserve the path-up traversal across the deeper directory; without
   that fix the slow tier would have skipped silently rather than run
   (PR #30 / POD-029).
+- Major-version caps on the three open-bound runtime deps in
+  `pyproject.toml` — `faster-whisper>=1.2,<2.0`,
+  `huggingface_hub>=1.12,<2.0`, `mlx-whisper>=0.4,<0.5` (the 0.x
+  one is capped at the next minor since SemVer 0.x treats minors
+  as breakable). Lower bounds bumped to the currently-locked
+  minor so a downstream venv can't silently downgrade below what
+  CI tests against. R-14 / R-17 mitigation — Dependabot's
+  grouped weekly PR brings minor + patch upstream bumps under
+  the cap; major bumps stay individual review per the dependabot
+  config landed in PR #33. `inaspeechsegmenter==0.7.6` and
+  `numpy>=1.26,<2.0` already had bounds and are unchanged
+  (PR #TBD).
+- CI matrix Ubuntu runner pinned: `ubuntu-latest` →
+  `ubuntu-24.04` in `.github/workflows/ci.yml`. R-13-shaped
+  Linux-side companion to the existing `macos-14` pin and to
+  the `ubuntu-24.04` already in `pip-audit.yml` (PR #33). Both
+  pins block the silent-CI-rollover failure mode where a fresh
+  GitHub-hosted image lands and breaks an existing build
+  mid-sprint (PR #TBD).
 
 ### Maintainer runbook
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,14 +288,14 @@ major-version bump per SemVer.
   the cap; major bumps stay individual review per the dependabot
   config landed in PR #33. `inaspeechsegmenter==0.7.6` and
   `numpy>=1.26,<2.0` already had bounds and are unchanged
-  (PR #TBD).
+  (PR #38).
 - CI matrix Ubuntu runner pinned: `ubuntu-latest` →
   `ubuntu-24.04` in `.github/workflows/ci.yml`. R-13-shaped
   Linux-side companion to the existing `macos-14` pin and to
   the `ubuntu-24.04` already in `pip-audit.yml` (PR #33). Both
   pins block the silent-CI-rollover failure mode where a fresh
   GitHub-hosted image lands and breaks an existing build
-  mid-sprint (PR #TBD).
+  mid-sprint (PR #38).
 
 ### Maintainer runbook
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,19 @@ authors = [{ name = "Juan García" }]
 license = "MIT"
 license-files = ["LICENSE"]
 dependencies = [
-    "faster-whisper>=1.0",
-    "huggingface_hub>=0.24",
+    # Major-version capped (R-14, R-17 mitigation). Lower bound matches the
+    # current locked minor so a downstream venv can't silently downgrade
+    # below what CI tests against. Dependabot's grouped weekly PR
+    # (.github/dependabot.yml) brings minor + patch bumps under the cap;
+    # major bumps stay individual review per the cap shape.
+    "faster-whisper>=1.2,<2.0",
+    "huggingface_hub>=1.12,<2.0",
     "inaspeechsegmenter==0.7.6",
-    "mlx-whisper>=0.4 ; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    # mlx-whisper is in 0.x — SemVer treats 0.x minors as breakable, so
+    # the symmetric "next breakable bump" cap is <0.5, not <1.0. Tighter
+    # than the >=1.0 deps' major-cap on purpose; loosen to <1.0 once
+    # mlx-whisper crosses 1.0.
+    "mlx-whisper>=0.4,<0.5 ; sys_platform == 'darwin' and platform_machine == 'arm64'",
     # Pinned <2 for inaSpeechSegmenter 0.7.6 compatibility — its 0.7.x
     # branch uses ``np.lib.pad`` (removed in 2.x) and the older positional
     # forms of ``np.stack``/``np.concatenate`` that numpy 2.x rejects.

--- a/uv.lock
+++ b/uv.lock
@@ -1732,10 +1732,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "faster-whisper", specifier = ">=1.0" },
-    { name = "huggingface-hub", specifier = ">=0.24" },
+    { name = "faster-whisper", specifier = ">=1.2,<2.0" },
+    { name = "huggingface-hub", specifier = ">=1.12,<2.0" },
     { name = "inaspeechsegmenter", specifier = "==0.7.6" },
-    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.4" },
+    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.4,<0.5" },
     { name = "numpy", specifier = ">=1.26,<2.0" },
     { name = "rich", specifier = ">=13.7" },
     { name = "tf-keras", specifier = ">=2.18.0" },


### PR DESCRIPTION
## Summary
- Two SP-8 cross-cutting pins from `PROJECT_PLAN.md:310`, grouped because they're mechanically tiny and share the same "freeze v1.0 surface area before tagging" rationale.
- **R-14 / R-17** — major-version caps on `faster-whisper` (`>=1.2,<2.0`), `huggingface_hub` (`>=1.12,<2.0`), `mlx-whisper` (`>=0.4,<0.5` — tighter because mlx-whisper is in 0.x and SemVer 0.x treats minors as breakable).
- **R-13** — `ubuntu-latest` matrix entry → `ubuntu-24.04` in `.github/workflows/ci.yml`. Symmetric to the existing `macos-14` pin and the `ubuntu-24.04` already in `pip-audit.yml`.
- Unblocks v0.1.0 tagging — the tag captures pinned deps + pinned runners, so the released artefact is reproducible.

## Acceptance criteria satisfied
- [x] **AC-1** — `pyproject.toml` pins three deps with major-version caps; lower bounds bumped to current locked minor; `inaspeechsegmenter==0.7.6` and `numpy>=1.26,<2.0` (already bounded) untouched.
- [x] **AC-2** — `ci.yml` matrix pinned: `ubuntu-latest` → `ubuntu-24.04`; `macos-14` already there.
- [x] **AC-3** — `uv lock` re-resolves cleanly; lockfile delta is only the spec strings (versions held: `1.2.1` / `1.12.0` / `0.4.3`); `uv sync --frozen` re-syncs without rebuilding any package.
- [x] **AC-4** — Each new bound carries an inline rationale comment naming R-14 / R-17 / R-13 + the Dependabot interplay; matches the precedent of the existing `numpy<2` rationale block.

## Strategy choice (b — major-version cap)
Plan §6 SP-8 cross-cutting calls for "minor version pin". I picked **strategy (b)** — major-version cap, lower bound at the locked minor — over the literal-minor reading because:

- **(a) literal minor pin** (`~=1.2.0`) means *every* upstream minor release needs a manual pin bump on our side, fighting the Dependabot grouped weekly PR (PR #33) — Dependabot proposes the bump, our pin blocks it, the PR loops.
- **(b) major cap** lets Dependabot's minor-batched weekly PR land minor + patch upstream bumps under the cap; major bumps stay individual review per the `dependabot.yml` group-by-update-type rule. Major bumps are the real "potentially breaking" signal anyway — a minor bump under SemVer is non-breaking by definition.

Asymmetry for `mlx-whisper`: it's in 0.x. SemVer 0.x treats minors as breakable, so the symmetric "next breakable bump" cap is `<0.5`, not `<1.0`. Documented inline; loosen to `<1.0` once mlx-whisper crosses 1.0.

User signed off on (b); maintainer's call confirmed in the announcement thread.

## Edge cases covered
- [x] **Lower-bound bump on `huggingface_hub`** — went from `>=0.24` (legacy from before the 1.0 release) to `>=1.12` to match what CI actually tests against. Nothing in the project has been built or tested on the 0.x branch since.
- [x] **Platform marker preserved** for `mlx-whisper`: `; sys_platform == 'darwin' and platform_machine == 'arm64'` carried through verbatim. Linux `uv sync` still skips it.
- [x] **No version drift** — `uv lock` chose the same versions it had before (1.2.1 / 1.12.0 / 0.4.3 all within the new bounds).
- [x] **Dependabot ignore rules untouched** — the `numpy` major + `inaspeechsegmenter` ignores landed in PR #33 still apply; this PR doesn't touch `dependabot.yml`.
- [x] **`pip-audit` workflow unaffected** — already pinned to `ubuntu-24.04` in PR #33; this PR brings `ci.yml` in line.

## Risks touched
- **R-13 (Ops)** — GitHub Actions runner-image rollover. Now mitigated on both runners.
- **R-14 (Tech)** — `huggingface_hub` upstream churn breaking the first-run notice contract. Major cap blocks the major-bump regression vector.
- **R-17 (Tech)** — `faster-whisper` / `mlx-whisper` upstream churn breaking the WhisperBackend Protocol invariants. Major caps block the major-bump regression vector; Tier 2 contract tests (PR #29 / POD-030) still catch fake-vs-real drift inside the allowed minor range.

## Documentation updated
- [x] `pyproject.toml` — inline rationale comment block on the new bounds.
- [x] `.github/workflows/ci.yml` — inline rationale comment on the matrix block.
- [x] `CHANGELOG.md` `[Unreleased] ### Changed` — two bullets, one per pin set.

## Test plan
- [x] `uv lock` → "Resolved 120 packages in 525ms"; no version drift.
- [x] `uv sync --frozen` → 1 metadata-only re-link of the local package; no rebuilds.
- [x] `uv run pytest -q` → 252 passed (Tier 1 unchanged).
- [x] `uv run ruff check` / `ruff format --check` / `mypy --strict` → clean (44 files).
- [ ] CI matrix on `ubuntu-24.04` + `macos-14`: expected green; same toolchain + same dep resolution.

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target.
- [x] No code change → no AC re-verification needed.
- [x] CHANGELOG `[Unreleased] ### Changed` updated.
- [x] Story status: SP-8 dep-pin + runner-pin tasks closed.
- [ ] CI matrix box (filled post-merge).
- [ ] Maintainer signoff at sprint review.

After this lands, SP-8 remaining work is **POD-038 sprint-actuals fill-in** + **POD-039 v0.1.0 tag** + **POD-040 v1.0.0 tag** (gated on dogfooders).

Refs R-13, R-14, R-17, PROJECT_PLAN.md §6 SP-8 cross-cutting list, §10 risk register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)