### PR TITLE
docs: dogfooding guide for the v0.1.0 → v1.0.0 phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,20 @@ major-version bump per SemVer.
 
 ## [Unreleased]
 
-_(no entries yet — post-v0.1.0 work lands here.)_
+### Added
+
+- `docs/DOGFOODING.md` — invitation guide for the v0.1.0 → v1.0.0
+  dogfooder phase per `PROJECT_PLAN.md` §8 / Q7. Covers prerequisites,
+  step-by-step install + smoke test + run-on-own-audio flow, an
+  evaluation checklist (transcript quality, music markers, output
+  format, UX), GitHub Issues feedback templates (env block + bug-shaped
+  vs. quality-shaped reports), the documented v1 limitations that are
+  *not* bugs (so dogfooders don't burn cycles on EC-1 / model-size /
+  no-batch / atomic-rename-no-partial), the Q7 acceptance bar
+  reflected as pass/fail, and a copy-paste-ready DM template the
+  maintainer can use to invite people. README has a one-paragraph
+  pointer between "Development" and "License" so an invited dogfooder
+  who lands on the README first finds the guide (PR #TBD).
 
 ## [0.1.0] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ major-version bump per SemVer.
   reflected as pass/fail, and a copy-paste-ready DM template the
   maintainer can use to invite people. README has a one-paragraph
   pointer between "Development" and "License" so an invited dogfooder
-  who lands on the README first finds the guide (PR #TBD).
+  who lands on the README first finds the guide (PR #42).
 
 ## [0.1.0] - 2026-05-02
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,16 @@ The architecture lives in
 [`SRS.md`](SRS.md); the sprint plan in
 [`PROJECT_PLAN.md`](PROJECT_PLAN.md).
 
+## For invited dogfooders
+
+If you've been invited to test `v0.1.0` ahead of the `v1.0.0` cut —
+welcome, and read [`docs/DOGFOODING.md`](docs/DOGFOODING.md) first.
+It walks through what's being asked (~30–60 minute commitment), the
+Q7 success bar (run the README quickstart on your own audio without
+needing maintainer help), and how to file feedback that actually
+moves the project forward. Pin your clone to the `v0.1.0` tag, not
+`main`, so every dogfooder is testing the same surface.
+
 ## License
 
 MIT — see [`LICENSE`](LICENSE) for the full text. Declared canonically

--- a/docs/DOGFOODING.md
+++ b/docs/DOGFOODING.md
@@ -1,0 +1,416 @@
+# Dogfooding `podcast-script` v0.1.0
+
+You've been invited to test `v0.1.0` ahead of the `v1.0.0` release. This
+guide walks you through what's being asked, what the success bar looks
+like, and how to file feedback that actually moves the project forward.
+
+If anything in this guide is unclear, **that itself is a finding worth
+reporting** — the bar set in `PROJECT_PLAN.md` §8 / Q7 is *"did the
+README quickstart get them to a transcript without help?"*. If you
+need to DM the maintainer to make the tool work, that's a doc bug.
+
+---
+
+## TL;DR — what you're agreeing to
+
+- **Time commitment.** ~30–60 minutes for one full pass. You're not
+  signing up for ongoing maintenance.
+- **What you'll do.** Follow `README.md` end-to-end on the bundled
+  fixture, then run the tool on a real podcast episode of your own,
+  then file at least one GitHub issue with what you found.
+- **What you need.** A macOS or Linux machine with ~3 GB free disk,
+  a network connection (for the first-run model download), and a
+  10–30 minute MP3 / audio file from a podcast you've worked on.
+- **Where feedback goes.** GitHub Issues — `https://github.com/invaderDMG/podcast-script/issues`. No DMs, no email, no
+  surveys (per `PROJECT_BRIEF.md` §17).
+- **Your tag is `v0.1.0`.** Not `main`. Pinning to the tag means
+  every dogfooder is testing the exact same surface and your feedback
+  is comparable.
+
+If that fits your week, read on. If it doesn't, that's also fine —
+saying so is more useful than committing and ghosting.
+
+---
+
+## Before you start — prerequisites
+
+You need:
+
+- **OS:** macOS 14+ or a recent Ubuntu / Debian. Windows isn't a
+  supported platform in v1 (POSIX signal handling, `ffmpeg`-via-PATH,
+  and the file-locking semantics behind atomic write all assume
+  POSIX).
+- **Python 3.12 or newer.** Check with `python3 --version`. If you're
+  on 3.11 or older, install 3.12 — `uv` can do that for you in the
+  next step, but you may want a system-managed install.
+- **Disk space:**
+  - ~75 MB if you only run the `tiny` model (smoke-test only).
+  - ~1.5 GB if you want `medium` (recommended for evaluation).
+  - ~3 GB if you want `large-v3` (production quality, Apple Silicon
+    only — `mlx-whisper` won't run on Linux or Intel Mac).
+- **Network connection** for the first run. The chosen Whisper model
+  downloads from the Hugging Face Hub on first invocation; subsequent
+  runs are offline. The `inaSpeechSegmenter` library also fetches a
+  small model on first install — same story.
+- **An audio file you actually want to transcribe.** Ideally 10–30
+  minutes of your own podcast (or a public-domain episode you've
+  worked on). MP3, WAV, M4A, FLAC, OGG all work — anything `ffmpeg`
+  can decode. The point of dogfooding is "does this work on *your*
+  audio?", not "does this work on the author's fixture".
+
+If any of these are blockers (e.g. you're on Windows, or you don't
+have time to do a 30-minute episode test), file an issue with the
+title `[dogfood] blocker: <reason>` and stop here — that itself is
+useful feedback.
+
+---
+
+## Step 1 — Install
+
+Three system bits, then the project:
+
+```sh
+# (1) uv — Python package manager. One-time install.
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# Restart your shell or run: source $HOME/.local/bin/env
+
+# (2) ffmpeg — audio decoder. Required at runtime.
+brew install ffmpeg              # macOS
+sudo apt-get install ffmpeg      # Debian / Ubuntu
+
+# (3) the project itself. Pin to v0.1.0 — not main.
+git clone https://github.com/invaderDMG/podcast-script.git
+cd podcast-script
+git checkout v0.1.0              # important — pin the surface
+uv sync                          # creates .venv with locked deps
+```
+
+**Sanity check** — confirm the CLI is reachable:
+
+```sh
+uv run podcast-script --help
+```
+
+You should see the flag list. If `uv run` errors with "command not
+found" or `uv sync` failed, **stop and file an issue** — this is
+exactly the install-doc gap Q7 is meant to surface.
+
+---
+
+## Step 2 — Smoke test on the bundled fixture
+
+Before you point the tool at your own audio, verify the install works
+end-to-end on the test fixture that ships with the repo:
+
+```sh
+uv run podcast-script examples/sample.mp3 \
+    --lang es --model tiny --backend faster-whisper \
+    -o /tmp/sample.md
+```
+
+What to expect:
+
+- A `rich` progress bar with three named phases (decode / segment /
+  transcribe), or — if your terminal is piped — plain logfmt event
+  lines on stderr (`event=startup` ... `event=done`).
+- The first run downloads the `faster-whisper tiny` model
+  (~75 MB). A `event=model_download` line fires within ~1 second of
+  startup so you know it's working, not hung. Subsequent runs are
+  instant from cache.
+- An output file at `/tmp/sample.md` shaped roughly like:
+
+  ```markdown
+  `00:01`  Las fabulaste es opo,
+
+  `00:03`  grabado para librevox.org por Christina Chu.
+
+  > [00:25 — music starts]
+  > [00:35 — music ends]
+  ```
+
+If this works: great, your environment is good. **Move to Step 3.**
+
+If it doesn't: file an issue with the title `[dogfood] smoke test
+failed: <one-line summary>` and include:
+
+- Your OS + chip (`uname -a`).
+- The full stderr output of the run.
+- The exit code (`echo $?` after the failed run).
+
+The smoke test failing is the most valuable possible finding — it
+means a real user will hit the same wall.
+
+---
+
+## Step 3 — Run it on your own audio
+
+This is the actual dogfooding bit.
+
+Pick an episode (10–30 min ideal — long enough to have music
+transitions, short enough to not eat your afternoon). Pick a model:
+
+- **`medium`** is the recommended starting point for evaluation —
+  good quality on CPU, ~1.5 GB download, real-world speeds.
+- **`large-v3`** if you're on Apple Silicon and want production
+  quality — uses `mlx-whisper` automatically.
+- Avoid `tiny` and `base` for evaluation; they're noisy by design
+  (intended for smoke tests, not assessment).
+
+```sh
+# Replace path/to/your/episode.mp3 with a real file.
+uv run podcast-script ~/path/to/your/episode.mp3 \
+    --lang es \
+    --model medium \
+    -o ~/Desktop/episode-transcript.md
+```
+
+(Substitute `--lang es` with one of the eight supported codes:
+`es / en / pt / fr / de / it / ca / eu`. If your podcast is in a
+language outside that set — `ja`, `zh`, `ru`, etc. — file an issue
+saying so; that's a v1 limitation we should know is hurting you.)
+
+Watch what happens:
+
+- Did the progress bar render correctly?
+- Did `event=transcribe_start` fire and ticks advance?
+- Did the run complete? Exit code 0?
+- How long did it take? (Compare to the "Observed throughput" table
+  in `README.md` — flag if you're substantially slower.)
+
+When done, **open the output Markdown** and read it. Read it like
+you're going to publish it.
+
+---
+
+## Step 4 — Evaluate
+
+Open `~/Desktop/episode-transcript.md` (or wherever you sent the
+output) and answer these as you read:
+
+### Transcript quality
+
+- Is the speech text accurate enough to publish? Where it's wrong,
+  is it the kind of wrong you can fix with `grep` / find-replace,
+  or the kind that needs a re-listen?
+- Are there obvious word-boundary glitches (`fabulaste` instead of
+  `fábulas` in the smoke test, e.g.)?
+- Did the language code (`--lang es`) actually constrain Whisper, or
+  did it switch into a wrong language partway through?
+
+### Music markers
+
+- Are the music regions in your episode marked? Did the marker
+  timestamps line up with what you remember (~1-2 second tolerance
+  is normal)?
+- Were there music regions the tool *missed*? Quiet music under
+  speech is the documented blind spot (`README.md` § "Accuracy
+  caveats", EC-1) — note any examples.
+- Were there false positives — text-only regions marked as music?
+
+### Output format
+
+- Are the timestamps the format you expected (`MM:SS` for episodes
+  under an hour, `HH:MM:SS` for an hour or more)?
+- Does the Markdown render correctly in your editor / preview tool?
+- Is the structure useful for your downstream workflow (publishing
+  to your podcast platform, importing into a CMS, etc.)?
+
+### UX
+
+- Was anything in the install process unclear?
+- Did the progress bar give you confidence the tool was making
+  progress? Did the first-run download notice fire fast enough that
+  you didn't think it had hung?
+- Were any error messages cryptic or unhelpful?
+- Anything you tried to do that the tool refused, that surprised
+  you?
+
+You don't need to write a 10-page review. Three or four bullet points
+covering "what worked, what didn't, what surprised me" is exactly
+right.
+
+---
+
+## Step 5 — File feedback
+
+**Where:** GitHub Issues only — `https://github.com/invaderDMG/podcast-script/issues`. Per `PROJECT_BRIEF.md` §17, this is the
+canonical channel; no DMs, no email, no surveys.
+
+**Title prefix:** start with `[dogfood]` so the maintainer can
+distinguish dogfooder findings from issues filed later by general
+users. Examples:
+
+- `[dogfood] smoke test failed on macOS 15.2 — ffmpeg version mismatch`
+- `[dogfood] missed music marker at 12:47 (intro fade-out under VO)`
+- `[dogfood] medium model: transcript quality unusable for editorial publishing`
+- `[dogfood] install: 'uv sync' failed without ffmpeg on PATH and the error message wasn't clear`
+- `[dogfood] positive: ran the README quickstart end-to-end without help in <20 minutes`
+
+The last shape is genuinely useful — Q7's acceptance bar is "did the
+README quickstart work without help?" and a confirmation issue
+explicitly answers it.
+
+### What to include in a bug-shaped issue
+
+For anything that crashed or misbehaved, include:
+
+```markdown
+## Environment
+- OS + chip: <output of `uname -a`>
+- Python: <output of `python3 --version`>
+- uv: <output of `uv --version`>
+- ffmpeg: <output of `ffmpeg -version | head -1`>
+- Project version: v0.1.0 (commit <output of `git rev-parse HEAD`>)
+
+## Reproduction
+The exact CLI invocation:
+\`\`\`sh
+uv run podcast-script <args>
+\`\`\`
+
+## Expected
+<what you thought would happen>
+
+## Actual
+<what happened — paste the full stderr; logfmt is grep-friendly>
+
+## Audio
+<any sharable detail — duration, language, music density. Don't
+upload the audio itself unless the issue is genuinely audio-content-
+specific>
+```
+
+For a crash specifically — re-run with `--debug` and attach (or
+sanitise + paste) the contents of `<input-stem>.debug/`:
+
+- `decoded.wav` — usually skip; it's the input as PCM.
+- `segments.jsonl` — the `inaSpeechSegmenter` output. Useful if
+  music markers are wrong.
+- `transcribe.jsonl` — partial transcript, line-flushed. Useful if
+  the run died mid-transcribe.
+- `commands.txt` — the exact `ffmpeg` argv used. Useful if decode
+  failed.
+
+### What to include in a quality-shaped issue
+
+For "the transcript was bad" / "the markers were wrong" / "this UX
+confused me", a free-form report is fine. Helpful:
+
+- A few specific timestamps where the issue shows up.
+- The language + model combination you ran.
+- One or two-line excerpts of what you expected vs. what you got.
+- Whether the issue reproduced if you re-ran with the same
+  invocation.
+
+---
+
+## What's already known and *not* a bug
+
+To save you (and the maintainer) cycles, these are documented v1
+limitations — please don't file issues for them unless you have
+specific data showing they're worse than the docs imply:
+
+- **Quiet music under speech may not be marked** (`README.md` §
+  "Accuracy caveats", EC-1, R-2). The segmenter is energy-based; a
+  music bed quieter than the voice over it can read as pure speech.
+  Specific cases where this hurts your workflow are valuable
+  signals; "this happened once" probably isn't.
+- **`tiny` and `base` produce noisy text.** They exist for smoke
+  tests. If you used them for evaluation, that's the bug.
+- **No batch / glob / directory input.** One file per invocation,
+  by design (SRS §1.3 Out of scope).
+- **No auto language detection.** `--lang` is required; eight codes
+  only. Adding a code is a docs+test PR for v2, not a bug in v1.
+- **Single voice / no diarization.** v1 doesn't separate speakers.
+  Output is one continuous speech stream interleaved with music
+  markers. Speaker labels are explicit non-goals.
+- **No GUI.** CLI only.
+- **Mid-run interruption produces no partial output.** This is the
+  atomic-write contract (NFR-5 / AC-US-6.3); a failed run leaves
+  any prior `episode.md` byte-for-byte intact, but the in-flight
+  run produces *nothing* on the output path. Restart from scratch.
+- **macOS Apple Silicon vs. Linux backend split.** `mlx-whisper`
+  on Apple Silicon (uses the Neural Engine), `faster-whisper`
+  everywhere else. `--backend mlx-whisper` on a non-Apple-Silicon
+  machine exits 2 by design.
+- **Anything in the locked CLI grammar / 22-token event catalogue /
+  exit-code policy.** Those are documented v1 contracts (`SRS.md`
+  §16.1); changes happen at major-version bumps, not in response
+  to feedback. Liking-or-disliking the names is fine to mention,
+  not a v1 fix.
+
+---
+
+## Pass / fail — the Q7 acceptance bar
+
+Per `PROJECT_PLAN.md` §8, the dogfooder phase passes when *"at least
+one external dogfooder has run the quickstart end-to-end without
+help, before the v1.0.0 tag"*. Concretely:
+
+- ✅ **Pass:** you cloned the repo at `v0.1.0`, ran `uv sync`, ran
+  the quickstart on your own audio, got a transcript out, and filed
+  at least one issue (positive or negative). You did this without
+  needing to DM the maintainer.
+- ❌ **Fail:** you got stuck somewhere and had to ask for help to
+  unstick. The "fail" outcome **is the point of dogfooding** — it
+  tells the maintainer the README has a hole. File an issue
+  describing exactly where you got stuck.
+
+There's no third state. "I tried and gave up" without filing
+anything is the worst outcome — silently failing tells the
+maintainer nothing.
+
+---
+
+## After v1.0.0
+
+Once v1.0.0 ships, the dogfooder phase is over and the project goes
+to `Public` user-testing per `PROJECT_PLAN.md` §8 (anyone who picks
+up the repo, GitHub Issues triaged at sprint planning). Your
+dogfooder issues are **not** retroactively converted to support
+tickets — the issue tracker becomes a normal open-source backlog,
+and issues that were dogfooder-specific framings ("this confused me
+when I was the first person to try this") may be closed as resolved
+or out-of-scope based on whether the underlying problem still
+applies.
+
+If you wanted to keep contributing post-v1.0.0 — patches, more
+issues, helping triage — that's welcome. The maintainer will reach
+out separately if there's a fit.
+
+---
+
+## Acknowledgements
+
+Thank you for the time. The maintainer-bus-factor risk
+(`PROJECT_PLAN.md` §10 R-9) is real for a solo project, and external
+dogfooding is one of the structural mitigations. Your "this confused
+me" is more valuable than your "this worked great" — both kinds of
+feedback help, but the former is what closes the gap between "the
+maintainer can use it" and "anyone who follows the docs can use it".
+
+---
+
+## For the maintainer — invitation template
+
+If you (the maintainer) are reading this, here's a copy-paste-ready
+DM for inviting a dogfooder. Replace `{NAME}` with their name and
+adjust as needed:
+
+> Hey {NAME} — I just shipped `v0.1.0` of a small CLI tool I've been
+> building, `podcast-script`. It segments podcast audio into speech
+> vs. music regions and runs Whisper only on the speech (so no
+> hallucinated "lyrics" over your music beds). I'm looking for one
+> or two podcast producers to dogfood it on a real episode of theirs
+> before I cut `v1.0.0`.
+>
+> Time commitment is about an hour: install, run on the bundled
+> fixture, run on something of yours, file an issue with what you
+> found.
+>
+> Repo + dogfooder guide:
+> https://github.com/invaderDMG/podcast-script/blob/v0.1.0/docs/DOGFOODING.md
+>
+> Pin to the `v0.1.0` tag so everyone's testing the same surface.
+> No worries if it's not your week — saying so is more useful than
+> committing and ghosting.


### PR DESCRIPTION
## Summary
- New `docs/DOGFOODING.md` (~416 lines, 17 sections) — the invitation guide for the v0.1.0 → v1.0.0 dogfooder phase per `PROJECT_PLAN.md` §8 / Q7.
- README pointer between `## Development` and `## License` so invited dogfooders who land on the README first find the guide.
- CHANGELOG `[Unreleased] ### Added` entry (first post-v0.1.0 entry; replaces the `(no entries yet)` placeholder).
- Pure prose. Zero code, zero test, zero config.

## Why now
Per `PROJECT_PLAN.md:339`, the dogfooder phase begins at M-7 (now — `v0.1.0` shipped at PR #40). Q7's acceptance bar is *"at least one external dogfooder has run the quickstart end-to-end without help, before the v1.0.0 tag."* The maintainer needs something concrete to send when DMing prospects; this PR provides it.

POD-040 (`v1.0.0` tag) is gated on this phase succeeding. Without a guide, the choice is "send a wall-of-text DM" or "hope they figure out the README on their own" — neither lands a useful dogfooder signal.

## What the guide covers
- **TL;DR** — time commitment (30–60 min), what they'll do, what they need, where feedback goes.
- **Prerequisites** — OS, Python, disk, network, "your own audio" as the load-bearing input.
- **Step-by-step install** — uv + ffmpeg + `git checkout v0.1.0` (not `main` — pin the surface so dogfooder feedback is comparable).
- **Smoke test** on the bundled fixture before running on their own audio.
- **Run on their own audio** — model-choice guidance (recommend `medium` minimum for evaluation; `tiny`/`base` are smoke-test-only).
- **Evaluation checklist** — transcript quality / music markers / output format / UX, with concrete questions in each category.
- **Feedback templates** — bug-shaped (env block + repro + expected / actual + `--debug` artefacts) vs. quality-shaped (free-form with timestamps + invocation).
- **What's already known and NOT a bug** — explicit list of documented v1 limitations (EC-1 quiet music, tiny/base noise, no batch, no auto-detect, single voice, no GUI, atomic-rename-no-partial, Apple Silicon vs. Linux backend split, locked CLI/event/exit contracts). Saves cycles by setting expectations.
- **Q7 pass/fail bar** — pass = quickstart-without-DMs + at least one issue filed; fail = got stuck and had to ask. The "fail" outcome IS the point of dogfooding (it tells the maintainer the README has a hole).
- **Post-v1.0.0 transition** — sets expectation that dogfooder issues aren't retroactively support tickets when the project moves to "Public" testing per §8.
- **Invitation DM template** — copy-paste-ready text for the maintainer to use when inviting prospects, pointing at the `v0.1.0`-pinned guide URL on GitHub.

## Acceptance criteria
- [x] **AC-1** — `docs/DOGFOODING.md` exists; covers prerequisites, install, smoke test, run-on-own-audio, evaluation, feedback, scope expectations, time commitment.
- [x] **AC-2** — Q7 acceptance bar reflected in pass/fail framing ("did the README quickstart get them to a transcript without help?").
- [x] **AC-3** — GitHub Issues feedback path with explicit env-block + bug-shaped + quality-shaped templates per `PROJECT_BRIEF.md` §17 (no DMs, no email, no surveys).
- [x] **AC-4** — README has a single pointer to the guide between `## Development` and `## License`. Audience flow: use → develop → dogfood → boilerplate.
- [x] **AC-5** — CHANGELOG `[Unreleased] ### Added` updated; the `(no entries yet)` placeholder is replaced since this is now the first post-v0.1.0 entry.
- [x] **AC-6** — Invitation DM template included for the maintainer's use.

## Edge cases covered
- [x] **Dogfooders who can't participate** — guide says "saying no is more useful than committing and ghosting", and a `[dogfood] blocker: <reason>` issue title is provided for blockers like Windows OS.
- [x] **Smoke test failure** — handled before "run on your own audio" so a broken environment is caught early; the guide says "stop and file an issue" with full template.
- [x] **Language outside the 8-code set** — guide explicitly invites a `[dogfood]` issue for "my podcast is in `ja`/`zh`/`ru`/etc." (a v1 limitation that should be known if it's hurting them).
- [x] **Quality-shaped vs. bug-shaped feedback** — templates differ (env-block + crash dump for bugs; timestamps + excerpts for quality). Reduces friction of writing the issue.
- [x] **Documented v1 limitations** — explicit list so dogfooders don't re-file EC-1 / model-noise / no-batch as bugs. Pulls from `README.md` § "Accuracy caveats", `SRS.md` §1.3 Won't list, ADR-0014 / ADR-0005, and the locked NFR-9 / NFR-10 / §9.1 contracts.
- [x] **`v0.1.0` pin** — guide says "pin to the tag, not main" so feedback is comparable across multiple dogfooders.

## Risks touched
- **R-9 (Biz) — bus factor.** External dogfooding is one of the structural mitigations. The guide makes the dogfooder onboarding self-serve so the maintainer's time is freed from "explain it again to the next person".

## Documentation updated
- [x] `docs/DOGFOODING.md` — new file, 416 lines.
- [x] `README.md` — one paragraph pointer between `## Development` and `## License`.
- [x] `CHANGELOG.md` — `[Unreleased] ### Added` entry.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` / `mypy --strict` clean (44 files; no source touched).
- [x] `uv run pytest -q` → 252 passed (Tier 1 unaffected).
- [x] `wc -l docs/DOGFOODING.md` → 416 lines (substantial but scan-able with TOC-shaped headers).
- [x] `grep -c "^## " docs/DOGFOODING.md` → 17 sections.
- [ ] CI matrix (Ubuntu + macOS-14): expected green; doc-only diff.

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target.
- [x] No code change → no AC re-verification needed.
- [x] CHANGELOG `[Unreleased] ### Added` updated.
- [x] Story status: closes the doc-prep gap for the dogfooder phase. POD-040 (v1.0.0 tag) is now actually invitable.
- [ ] CI matrix box (filled post-merge).

After this lands, the maintainer can DM prospects with the template at the bottom of `DOGFOODING.md`, pointed at the `v0.1.0`-tagged guide URL.

Refs PROJECT_PLAN.md §8 (user-testing cadence), Q7 (acceptance bar), PROJECT_BRIEF.md §17 (GitHub Issues as canonical channel), R-9 (bus-factor mitigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)