### PR TITLE
chore: cut v0.1.1 — patch release for dogfooding guide + Dependabot triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,40 @@ major-version bump per SemVer.
   pointer between "Development" and "License" so an invited dogfooder
   who lands on the README first finds the guide (PR #42).
 
+### Changed
+
+- `actions/checkout` bumped v4 → v6 in both CI workflows
+  (`.github/workflows/ci.yml`, `.github/workflows/pip-audit.yml`).
+  First Dependabot grouped weekly PR after the v0.1.0 cut; major
+  bump so it landed individually rather than under the
+  `pip`/`actions` minor + patch group per the rules in
+  `.github/dependabot.yml` (PR #34).
+- `astral-sh/setup-uv` bumped v6 → v7 in both CI workflows. Same
+  pathway as `actions/checkout` above; rebased against
+  post-PR-#34/#38 main before merge so the matrix legs ran on
+  `ubuntu-24.04` (not the pre-pin `ubuntu-latest`) (PR #35).
+- Tightened the `numpy` Dependabot ignore in
+  `.github/dependabot.yml`: added `versions: [">=2.0"]` alongside
+  the existing `update-types: version-update:semver-major` filter.
+  The `update-types` filter only catches version-update PRs (i.e.
+  bumping the lockfile from 1.26.x to 2.x); it doesn't catch
+  *requirement-update* PRs (broadening `pyproject.toml`'s
+  `numpy<2.0` cap to `<3.0`) — which Dependabot proposed shortly
+  after v0.1.0 (closed PR #36). The `versions` filter applies to
+  both update modes, making the ignore defence-in-depth. Drop the
+  `versions` line at the same moment `inaspeechsegmenter` unpins
+  to ≥ 0.8.x with Apple Silicon support; the existing
+  `inaspeechsegmenter` ignore tracks the same trigger (PR #41,
+  refs closed PR #36).
+
+### Maintenance
+
+- Closed `PR #36` (Dependabot proposal to broaden `numpy>=1.26,<2.0`
+  to `<3.0`) without merging — the `<2.0` cap is deliberate per
+  `pyproject.toml:14-19` (inaSpeechSegmenter 0.7.6 incompatibility
+  with numpy 2.x). The `numpy` ignore tightening above (PR #41)
+  prevents the same proposal from recurring.
+
 ## [0.1.0] - 2026-05-02
 
 First usable release per `PROJECT_BRIEF.md` §16 — the test pyramid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ major-version bump per SemVer.
 
 ## [Unreleased]
 
+_(no entries yet — post-v0.1.1 work lands here.)_
+
+## [0.1.1] - 2026-05-02
+
+Patch release per SemVer 2.0.0 §4. No API changes; delta is the
+four PRs merged between v0.1.0 and v0.1.1: dogfooding guide,
+Dependabot action bumps, and Dependabot config tightening to
+prevent the closed PR #36's proposal class from recurring. The
+five `SRS.md` §16.1 contracts (output Markdown shape, 8-code
+`--lang` set, exit codes, logfmt format + 22-token catalogue, CLI
+grammar) are untouched. Cut to give invited dogfooders a real
+pinned tag with `docs/DOGFOODING.md` included — the v0.1.0 tag
+predates the guide.
+
 ### Added
 
 - `docs/DOGFOODING.md` — invitation guide for the v0.1.0 → v1.0.0
@@ -476,6 +490,14 @@ happen.
   variance record. v1.0.0 tag (POD-040) is still gated on
   dogfooder feedback per Q7 — the calendar acceleration does not
   shorten the human review window.
+- **v0.1.1 — actual 2026-05-02; not projected.** Same-day patch
+  release after v0.1.0; the §7 calendar table doesn't enumerate
+  patch tags (only major sprint milestones M-1..M-8), so this is a
+  no-projection variance — recorded for completeness rather than
+  schedule analysis. Cut to bundle the dogfooding guide
+  (PR #42) + Dependabot triage (#34, #35, #41) into a tag the
+  guide URL actually resolves under, since the v0.1.0 tag predates
+  the guide commit. No CI gate change vs. v0.1.0.
 
 ### Risk-register churn
 

--- a/README.md
+++ b/README.md
@@ -372,12 +372,12 @@ The architecture lives in
 
 ## For invited dogfooders
 
-If you've been invited to test `v0.1.0` ahead of the `v1.0.0` cut —
+If you've been invited to test `v0.1.1` ahead of the `v1.0.0` cut —
 welcome, and read [`docs/DOGFOODING.md`](docs/DOGFOODING.md) first.
 It walks through what's being asked (~30–60 minute commitment), the
 Q7 success bar (run the README quickstart on your own audio without
 needing maintainer help), and how to file feedback that actually
-moves the project forward. Pin your clone to the `v0.1.0` tag, not
+moves the project forward. Pin your clone to the `v0.1.1` tag, not
 `main`, so every dogfooder is testing the same surface.
 
 ## License

--- a/docs/DOGFOODING.md
+++ b/docs/DOGFOODING.md
@@ -1,6 +1,6 @@
-# Dogfooding `podcast-script` v0.1.0
+# Dogfooding `podcast-script` v0.1.1
 
-You've been invited to test `v0.1.0` ahead of the `v1.0.0` release. This
+You've been invited to test `v0.1.1` ahead of the `v1.0.0` release. This
 guide walks you through what's being asked, what the success bar looks
 like, and how to file feedback that actually moves the project forward.
 
@@ -23,7 +23,7 @@ need to DM the maintainer to make the tool work, that's a doc bug.
   10–30 minute MP3 / audio file from a podcast you've worked on.
 - **Where feedback goes.** GitHub Issues — `https://github.com/invaderDMG/podcast-script/issues`. No DMs, no email, no
   surveys (per `PROJECT_BRIEF.md` §17).
-- **Your tag is `v0.1.0`.** Not `main`. Pinning to the tag means
+- **Your tag is `v0.1.1`.** Not `main`. Pinning to the tag means
   every dogfooder is testing the exact same surface and your feedback
   is comparable.
 
@@ -78,10 +78,10 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 brew install ffmpeg              # macOS
 sudo apt-get install ffmpeg      # Debian / Ubuntu
 
-# (3) the project itself. Pin to v0.1.0 — not main.
+# (3) the project itself. Pin to v0.1.1 — not main.
 git clone https://github.com/invaderDMG/podcast-script.git
 cd podcast-script
-git checkout v0.1.0              # important — pin the surface
+git checkout v0.1.1              # important — pin the surface
 uv sync                          # creates .venv with locked deps
 ```
 
@@ -260,7 +260,7 @@ For anything that crashed or misbehaved, include:
 - Python: <output of `python3 --version`>
 - uv: <output of `uv --version`>
 - ffmpeg: <output of `ffmpeg -version | head -1`>
-- Project version: v0.1.0 (commit <output of `git rev-parse HEAD`>)
+- Project version: v0.1.1 (commit <output of `git rev-parse HEAD`>)
 
 ## Reproduction
 The exact CLI invocation:
@@ -347,7 +347,7 @@ Per `PROJECT_PLAN.md` §8, the dogfooder phase passes when *"at least
 one external dogfooder has run the quickstart end-to-end without
 help, before the v1.0.0 tag"*. Concretely:
 
-- ✅ **Pass:** you cloned the repo at `v0.1.0`, ran `uv sync`, ran
+- ✅ **Pass:** you cloned the repo at `v0.1.1`, ran `uv sync`, ran
   the quickstart on your own audio, got a transcript out, and filed
   at least one issue (positive or negative). You did this without
   needing to DM the maintainer.
@@ -397,7 +397,7 @@ If you (the maintainer) are reading this, here's a copy-paste-ready
 DM for inviting a dogfooder. Replace `{NAME}` with their name and
 adjust as needed:
 
-> Hey {NAME} — I just shipped `v0.1.0` of a small CLI tool I've been
+> Hey {NAME} — I just shipped `v0.1.1` of a small CLI tool I've been
 > building, `podcast-script`. It segments podcast audio into speech
 > vs. music regions and runs Whisper only on the speech (so no
 > hallucinated "lyrics" over your music beds). I'm looking for one
@@ -409,8 +409,8 @@ adjust as needed:
 > found.
 >
 > Repo + dogfooder guide:
-> https://github.com/invaderDMG/podcast-script/blob/v0.1.0/docs/DOGFOODING.md
+> https://github.com/invaderDMG/podcast-script/blob/v0.1.1/docs/DOGFOODING.md
 >
-> Pin to the `v0.1.0` tag so everyone's testing the same surface.
+> Pin to the `v0.1.1` tag so everyone's testing the same surface.
 > No worries if it's not your week — saying so is more useful than
 > committing and ghosting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "podcast-script"
-version = "0.1.0"
+version = "0.1.1"
 description = "Transcribe podcasts to Markdown with music segment markers."
 requires-python = ">=3.12"
 authors = [{ name = "Juan García" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1708,7 +1708,7 @@ wheels = [
 
 [[package]]
 name = "podcast-script"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
## Summary
- **v0.1.1 patch release.** Bundles the four PRs that landed between v0.1.0 (`6ddd9d6`) and HEAD into a tagged release the `docs/DOGFOODING.md` URL actually resolves under (the v0.1.0 tag predates the guide commit; the maintainer-DM template's URL would 404 against it).
- Pure release-prep diff: CHANGELOG promotion + version bump + DM-template URL refresh. Zero source / test / config touched.
- After this PR squash-merges, the `v0.1.1` tag lands as a separate confirmation gate.

## What's in v0.1.1 vs. v0.1.0
Four PRs in the delta:

| PR | Type | What |
|---|---|---|
| #34 | Changed | `actions/checkout` v4 → v6 (Dependabot major bump) |
| #35 | Changed | `astral-sh/setup-uv` v6 → v7 (Dependabot major bump, rebased post-#34/#38) |
| #41 | Changed | Tightened numpy Dependabot ignore — `versions: [">=2.0"]` filter prevents the closed PR #36's spec-broaden proposal from recurring |
| #42 | Added | `docs/DOGFOODING.md` invitation guide for the v0.1.0 → v1.0.0 phase |

Plus one closed PR (#36) recorded under `### Maintenance` in CHANGELOG: Dependabot's proposal to broaden `numpy<2.0 → <3.0` was refused because `pyproject.toml:14-19` documents that the cap is deliberate (inaSpeechSegmenter 0.7.6 incompatibility with numpy 2.x).

**No API changes.** Per SemVer 2.0.0 §4 + `CHANGELOG.md:31-32` file header, contract changes between `0.x` releases are minor-bumps; SemVer-major attaches at v1.0.0. The five `SRS.md` §16.1 contracts (Markdown shape, 8-code `--lang`, exit codes, logfmt + 22-token catalogue, CLI grammar) are byte-identical to v0.1.0.

## Acceptance criteria (PR scope)
- [x] **AC-1** — `pyproject.toml` version flipped `0.1.0` → `0.1.1`. `uv lock` re-resolved cleanly (only delta is the local-package version line; same 120 packages).
- [x] **AC-2** — CHANGELOG `[Unreleased]` content promoted to `## [0.1.1] - 2026-05-02`; fresh empty `[Unreleased]` placeholder above. The `[Unreleased]` block also got backfilled with the three `### Changed` bullets (#34, #35, #41) and one `### Maintenance` bullet (#36 close) before the promotion — those PRs merged without their own CHANGELOG entries at the time.
- [x] **AC-3** — `### Schedule slippage` second entry: v0.1.1 actual 2026-05-02, "not projected" framing (the §7 calendar table only enumerates major sprint milestones M-1..M-8, not patch tags).
- [x] **AC-4** — `docs/DOGFOODING.md` 10 `v0.1.0` references → `v0.1.1`. Includes the title, the prerequisites/install steps, the env-block template's "Project version" example, the Q7 pass/fail bar's clone-tag framing, and the maintainer-DM template URL.
- [x] **AC-5** — `README.md` `## For invited dogfooders` paragraph's two `v0.1.0` references → `v0.1.1`.

## Acceptance criteria deferred to post-merge
- [ ] **AC-6** — `v0.1.1` annotated tag pushed to origin pointing at this PR's squash-merge SHA. **Confirmation gate**: I'll pause for explicit user "tag and push" before executing `git tag -a v0.1.1 <sha> -m "..."` + `git push origin v0.1.1`.
- [x] **AC-7** — All three test tiers + lint/format/types green on branch HEAD (252 / 21 / 6 expected; CI matrix on the PR will confirm both runners).

## Edge cases covered
- [x] **Backfill before promotion** — three Dependabot PRs merged without their own CHANGELOG entries at the time. Adding them to `[Unreleased]` first and then promoting is the right K-a-C ordering; doing the promotion in one shot would lose the trail of what's *in* the release.
- [x] **`### Maintenance` subsection** — Keep-a-Changelog 1.1.0 only enumerates Added / Changed / Deprecated / Removed / Fixed / Security; using `Maintenance` as a small "rejected proposals worth recording" bucket since "closed PR #36" doesn't fit any of the K-a-C six. Reasonable extension; if the convention proves out it stays, otherwise it folds into `Changed` next release.
- [x] **`v0.1.0` historical references in CHANGELOG retained** — the `[0.1.1]` release note explicitly references "the v0.1.0 tag predates the guide", and the `### Schedule slippage` `v0.1.0` entry stays as the historical record. Only the *current-tag* references in DOGFOODING.md and README.md were updated.
- [x] **Lockfile delta minimal** — `uv lock` updated only the `podcast-script` self-version line (`0.1.0 → 0.1.1`); 119 transitive deps unchanged.
- [x] **Date semantics** — both `CHANGELOG.md:38` and the `### Schedule slippage` v0.1.1 entry hard-code `2026-05-02`. Pre-tag check (suggested in PR #40 review) will verify this still matches `date -u +%Y-%m-%d` at tag-push time; if the PR slips past UTC midnight before merge, push a small `docs: align release date to merge SHA's date` commit before tagging.

## Risks touched
- **R-9 (Biz) — bus factor.** v0.1.1 makes the dogfooder URL resolvable, which makes the maintainer's invitation-DM workflow self-serve. Direct mitigation contribution.
- **R-1 (Tech) / R-17 (Tech) — supply-chain churn.** The Dependabot config tightening (#41) and the action bumps (#34, #35) are bundled in this tag, so a downstream consumer pinning to v0.1.1 gets the hardened supply-chain surface.

## Documentation updated
- [x] `pyproject.toml` — version bump.
- [x] `uv.lock` — auto-refreshed via `uv lock`.
- [x] `CHANGELOG.md` — three changes:
  - Backfilled `[Unreleased]` `### Changed` + `### Maintenance` entries for #34, #35, #41, #36-close.
  - Promoted `[Unreleased]` content to `[0.1.1] - 2026-05-02` with one-paragraph release note.
  - Added v0.1.1 entry to `### Schedule slippage`.
- [x] `docs/DOGFOODING.md` — 10 `v0.1.0` → `v0.1.1` (URLs, prerequisites, DM template).
- [x] `README.md` — 2 `v0.1.0` → `v0.1.1` (dogfooder pointer paragraph).

## Test plan
- [x] `uv lock` → 120 packages resolved; only local-package version line changed.
- [x] `uv run ruff check` / `ruff format --check` / `mypy --strict` → clean (44 files).
- [x] `uv run pytest -q` → 252 passed, 27 deselected.
- [ ] CI matrix (`ubuntu-24.04` + `macos-14`): expected green; same coverage as v0.1.0 cut.

## Tagging plan (post-merge)
After this PR squash-merges:

```sh
git checkout main
git pull --ff-only
# verify HEAD is the squash-merge SHA
# verify CHANGELOG.md:38 ([0.1.1] - 2026-05-02) and the slippage entry's
#   date still match `date -u +%Y-%m-%d` (per PR #40 reviewer's suggestion)
git tag -a v0.1.1 -m "v0.1.1 — patch: dogfooding guide + Dependabot triage"
git push origin v0.1.1
```

I'll pause for explicit user "tag and push" confirmation before running these.

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target.
- [x] No code change → no AC re-verification beyond the four-tier suite green.
- [x] CHANGELOG promoted to `[0.1.1]` per Keep-a-Changelog hygiene.
- [x] PROJECT_PLAN.md untouched per §1.5 plan-governance (corrections in CHANGELOG instead).
- [ ] CI matrix box (filled post-merge).
- [ ] **`v0.1.1` tag pushed** (post-merge gate).

After this PR + tag, the dogfooder URL resolves, the maintainer can start sending the DM template, and SP-8 has only **POD-040** (`v1.0.0` tag + GitHub Release) remaining — gated on dogfooder feedback per Q7.

Refs v0.1.0 cut (PR #40), Dependabot triage (#34/#35/#36-close/#41), DOGFOODING (#42), PROJECT_BRIEF.md §16, PROJECT_PLAN.md §1.5 plan-governance, Keep-a-Changelog 1.1.0, SemVer 2.0.0 §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)