### PR TITLE
chore: cut v0.1.2 — patch release for dogfooder bug fixes (#44, #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,22 @@ major-version bump per SemVer.
 
 ## [Unreleased]
 
+_(no entries yet — post-v0.1.2 work lands here.)_
+
+## [0.1.2] - 2026-05-02
+
+Patch release per SemVer 2.0.0 §4. No API changes; delta is the
+single PR (#46) merged between v0.1.1 and v0.1.2 that fixes the two
+first dogfooder reports against v0.1.1: issue #45 (mlx-whisper bare
+shortname 401 against the HF API on every fresh-cache run) and
+issue #44 (CTranslate2 inferred-compute-type warning leaking past
+NFR-10's logfmt-only stderr promise on macOS arm64 CPU). The five
+`SRS.md` §16.1 contracts (output Markdown shape, 8-code `--lang`
+set, exit codes, logfmt format + 22-token catalogue, CLI grammar)
+are byte-identical to v0.1.1. Cut so dogfooders pinning to the
+guide URL get the working tag rather than v0.1.1's broken
+`--model large-v3` path.
+
 ### Fixed
 
 - **Issue #45** — `MlxWhisperBackend._build_model` now resolves bare
@@ -535,6 +551,15 @@ happen.
   (PR #42) + Dependabot triage (#34, #35, #41) into a tag the
   guide URL actually resolves under, since the v0.1.0 tag predates
   the guide commit. No CI gate change vs. v0.1.0.
+- **v0.1.2 — actual 2026-05-02; not projected.** Same-day second
+  patch release after v0.1.1, on the day the dogfooder phase
+  opened. Same no-projection framing as v0.1.1 — the §7 calendar
+  doesn't enumerate patch tags. Cut to ship the two first dogfooder
+  bug fixes (PR #46 — mlx-whisper bare shortname 401 against HF on
+  every fresh-cache run, ctranslate2 inferred-compute-type warning
+  on macOS arm64 CPU) so dogfooders pinning to the guide URL get a
+  working `--model large-v3` path and a clean stderr stream. No CI
+  gate change vs. v0.1.1; same Ubuntu + macOS-14 matrix.
 
 ### Risk-register churn
 

--- a/README.md
+++ b/README.md
@@ -372,12 +372,12 @@ The architecture lives in
 
 ## For invited dogfooders
 
-If you've been invited to test `v0.1.1` ahead of the `v1.0.0` cut —
+If you've been invited to test `v0.1.2` ahead of the `v1.0.0` cut —
 welcome, and read [`docs/DOGFOODING.md`](docs/DOGFOODING.md) first.
 It walks through what's being asked (~30–60 minute commitment), the
 Q7 success bar (run the README quickstart on your own audio without
 needing maintainer help), and how to file feedback that actually
-moves the project forward. Pin your clone to the `v0.1.1` tag, not
+moves the project forward. Pin your clone to the `v0.1.2` tag, not
 `main`, so every dogfooder is testing the same surface.
 
 ## License

--- a/docs/DOGFOODING.md
+++ b/docs/DOGFOODING.md
@@ -1,6 +1,6 @@
-# Dogfooding `podcast-script` v0.1.1
+# Dogfooding `podcast-script` v0.1.2
 
-You've been invited to test `v0.1.1` ahead of the `v1.0.0` release. This
+You've been invited to test `v0.1.2` ahead of the `v1.0.0` release. This
 guide walks you through what's being asked, what the success bar looks
 like, and how to file feedback that actually moves the project forward.
 
@@ -23,7 +23,7 @@ need to DM the maintainer to make the tool work, that's a doc bug.
   10–30 minute MP3 / audio file from a podcast you've worked on.
 - **Where feedback goes.** GitHub Issues — `https://github.com/invaderDMG/podcast-script/issues`. No DMs, no email, no
   surveys (per `PROJECT_BRIEF.md` §17).
-- **Your tag is `v0.1.1`.** Not `main`. Pinning to the tag means
+- **Your tag is `v0.1.2`.** Not `main`. Pinning to the tag means
   every dogfooder is testing the exact same surface and your feedback
   is comparable.
 
@@ -78,10 +78,10 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 brew install ffmpeg              # macOS
 sudo apt-get install ffmpeg      # Debian / Ubuntu
 
-# (3) the project itself. Pin to v0.1.1 — not main.
+# (3) the project itself. Pin to v0.1.2 — not main.
 git clone https://github.com/invaderDMG/podcast-script.git
 cd podcast-script
-git checkout v0.1.1              # important — pin the surface
+git checkout v0.1.2              # important — pin the surface
 uv sync                          # creates .venv with locked deps
 ```
 
@@ -260,7 +260,7 @@ For anything that crashed or misbehaved, include:
 - Python: <output of `python3 --version`>
 - uv: <output of `uv --version`>
 - ffmpeg: <output of `ffmpeg -version | head -1`>
-- Project version: v0.1.1 (commit <output of `git rev-parse HEAD`>)
+- Project version: v0.1.2 (commit <output of `git rev-parse HEAD`>)
 
 ## Reproduction
 The exact CLI invocation:
@@ -347,7 +347,7 @@ Per `PROJECT_PLAN.md` §8, the dogfooder phase passes when *"at least
 one external dogfooder has run the quickstart end-to-end without
 help, before the v1.0.0 tag"*. Concretely:
 
-- ✅ **Pass:** you cloned the repo at `v0.1.1`, ran `uv sync`, ran
+- ✅ **Pass:** you cloned the repo at `v0.1.2`, ran `uv sync`, ran
   the quickstart on your own audio, got a transcript out, and filed
   at least one issue (positive or negative). You did this without
   needing to DM the maintainer.
@@ -397,7 +397,7 @@ If you (the maintainer) are reading this, here's a copy-paste-ready
 DM for inviting a dogfooder. Replace `{NAME}` with their name and
 adjust as needed:
 
-> Hey {NAME} — I just shipped `v0.1.1` of a small CLI tool I've been
+> Hey {NAME} — I just shipped `v0.1.2` of a small CLI tool I've been
 > building, `podcast-script`. It segments podcast audio into speech
 > vs. music regions and runs Whisper only on the speech (so no
 > hallucinated "lyrics" over your music beds). I'm looking for one
@@ -409,8 +409,8 @@ adjust as needed:
 > found.
 >
 > Repo + dogfooder guide:
-> https://github.com/invaderDMG/podcast-script/blob/v0.1.1/docs/DOGFOODING.md
+> https://github.com/invaderDMG/podcast-script/blob/v0.1.2/docs/DOGFOODING.md
 >
-> Pin to the `v0.1.1` tag so everyone's testing the same surface.
+> Pin to the `v0.1.2` tag so everyone's testing the same surface.
 > No worries if it's not your week — saying so is more useful than
 > committing and ghosting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "podcast-script"
-version = "0.1.1"
+version = "0.1.2"
 description = "Transcribe podcasts to Markdown with music segment markers."
 requires-python = ">=3.12"
 authors = [{ name = "Juan García" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1708,7 +1708,7 @@ wheels = [
 
 [[package]]
 name = "podcast-script"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
## Summary
- **v0.1.2 patch release.** Bundles PR #46 (the two first dogfooder bug fixes against v0.1.1: issue #45 mlx-whisper bare shortname 401, issue #44 ctranslate2 inferred-compute-type warning) into a tagged release the dogfooder DM-template URL resolves under.
- Pure release-prep diff: CHANGELOG promotion + version bump + DM-template URL refresh. Zero source / test / config touched.
- After this PR squash-merges, the `v0.1.2` tag lands as a separate confirmation gate.

## What's in v0.1.2 vs. v0.1.1
One PR in the delta:

| PR | Type | What |
|---|---|---|
| #46 | Fixed | Dogfooder reports — mlx-whisper bare shortname 401 (#45), ctranslate2 inferred-compute-type warning on macOS arm64 CPU (#44) |

**No API changes.** Per SemVer 2.0.0 §4 + `CHANGELOG.md:31-32` file header, contract changes between `0.x` releases are minor-bumps; SemVer-major attaches at v1.0.0. The five `SRS.md` §16.1 contracts (Markdown shape, 8-code `--lang`, exit codes, logfmt + 22-token catalogue, CLI grammar) are byte-identical to v0.1.1.

## Acceptance criteria (PR scope)
- [x] **AC-1** — `pyproject.toml` version flipped `0.1.1` → `0.1.2`. `uv lock` re-resolved cleanly (only delta is the local-package self-version line; same 120 packages).
- [x] **AC-2** — CHANGELOG `[Unreleased]` content (the #44/#45 fix bullets that landed via PR #46) promoted to `## [0.1.2] - 2026-05-02`; fresh empty `[Unreleased]` placeholder above.
- [x] **AC-3** — `### Schedule slippage` third entry: v0.1.2 actual 2026-05-02, "not projected" framing mirroring the v0.1.1 entry.
- [x] **AC-4** — `docs/DOGFOODING.md` 10 `v0.1.1` references → `v0.1.2` (title, prerequisites/install steps, env-block template's "Project version" example, Q7 pass/fail bar, maintainer-DM template URL).
- [x] **AC-5** — `README.md` `## For invited dogfooders` paragraph's two `v0.1.1` references → `v0.1.2`.

## Acceptance criteria deferred to post-merge
- [ ] **AC-6** — `v0.1.2` annotated tag pushed to origin pointing at this PR's squash-merge SHA.
- [x] **AC-7** — Lint / type / unit tier green on branch HEAD (ruff clean, mypy clean on 44 files, 265 unit tests passing); CI matrix on the PR will confirm the contract + integration tiers across both runners.

## Edge cases covered
- [x] **`v0.1.1` historical references in CHANGELOG retained** — the `[0.1.2]` release note explicitly references "v0.1.1's broken `--model large-v3` path", and the `### Schedule slippage` `v0.1.1` entry stays as the historical record. Only the *current-tag* references in DOGFOODING.md and README.md were updated.
- [x] **Lockfile delta minimal** — `uv lock` updated only the `podcast-script` self-version line (`0.1.1 → 0.1.2`); 119 transitive deps unchanged.
- [x] **Date semantics** — both the new `## [0.1.2] - 2026-05-02` heading and the `### Schedule slippage` v0.1.2 entry hard-code `2026-05-02`. If this PR slips past UTC midnight before merge, push a small `docs: align release date to merge SHA's date` commit before tagging.

## Risks touched
- **R-9 (Biz) — bus factor.** v0.1.2 is the first dogfooder-feedback turn-around; demonstrates that the v0.1.0 → v1.0.0 phase actually closes the loop on reports. Direct mitigation contribution.
- **R-17 (Tech) — upstream lib API drift.** Both fixes are robustness against upstream lib behaviours (mlx-whisper's load_model resolves only fully-qualified repo ids; CT2's "default" compute_type warns on inferred fallback). Pinning to v0.1.2 means downstream dogfooders don't trip the same edges.

## Documentation updated
- [x] `pyproject.toml` — version bump.
- [x] `uv.lock` — auto-refreshed via `uv lock`.
- [x] `CHANGELOG.md` — three changes:
  - Promoted `[Unreleased]` content to `[0.1.2] - 2026-05-02` with one-paragraph release note.
  - Fresh empty `[Unreleased]` placeholder.
  - Added v0.1.2 entry to `### Schedule slippage`.
- [x] `docs/DOGFOODING.md` — 10 `v0.1.1` → `v0.1.2` (URLs, prerequisites, DM template).
- [x] `README.md` — 2 `v0.1.1` → `v0.1.2` (dogfooder pointer paragraph).

## Test plan
- [x] `uv lock` → 120 packages resolved; only local-package self-version line changed.
- [x] `uv run ruff check src tests` → clean.
- [x] `uv run mypy` → clean (44 files, strict).
- [x] `uv run pytest tests/unit -q` → 265 passed.
- [ ] CI matrix (`ubuntu-24.04` + `macos-14`): expected green; same coverage as v0.1.1 cut.

## Tagging plan (post-merge)
After this PR squash-merges:

```sh
git checkout main
git pull --ff-only
# verify HEAD is the squash-merge SHA
# verify CHANGELOG `[0.1.2] - 2026-05-02` and the slippage entry's
#   date still match `date -u +%Y-%m-%d`
git tag -a v0.1.2 -m "v0.1.2 — patch: dogfooder bug fixes (#44, #45)"
git push origin v0.1.2
```

## Definition of Done
- [x] Trunk-based feature branch, squash-merge target.
- [x] No code change → no AC re-verification beyond the four-tier suite green.
- [x] CHANGELOG promoted to `[0.1.2]` per Keep-a-Changelog hygiene.
- [x] PROJECT_PLAN.md untouched per §1.5 plan-governance.
- [ ] CI matrix box (filled post-merge).
- [ ] **`v0.1.2` tag pushed** (post-merge gate).

Refs PR #46 (the fix bundle), v0.1.1 cut (PR #43), Keep-a-Changelog 1.1.0, SemVer 2.0.0 §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)