### PR TITLE
fix: dogfood — replace mlx prefix rule with canonical-repo table (#45 v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,58 @@ major-version bump per SemVer.
 
 ## [Unreleased]
 
-_(no entries yet — post-v0.1.2 work lands here.)_
+### Fixed
+
+- **Issue #45 (re-fix)** — the v0.1.2 fix used a uniform
+  `mlx-community/whisper-{shortname}` prefix rule which still 404'd
+  on `base`, `small`, `medium`, and `large-v3` because those
+  shortnames are only published under the `-mlx` suffix
+  (`whisper-large-v3-mlx`, etc.). The naming is asymmetric across
+  the mlx-community org — `tiny` ships under both `whisper-tiny`
+  and `whisper-tiny-mlx`, `large-v3-turbo` ships only under the
+  unsuffixed `whisper-large-v3-turbo`, the rest are `-mlx`-only —
+  so a prefix rule cannot close the matrix. Replaced with an
+  explicit `_CANONICAL_MLX_REPOS` shortname → repo table verified
+  against the HuggingFace API on 2026-05-02; best-effort
+  `mlx-community/whisper-{shortname}` fallback retained for
+  unknown shortnames so future Whisper additions don't require a
+  code change in the common case
+  (`src/podcast_script/backends/mlx.py`).
+- **`MlxWhisperBackend._is_cached` cache anchor** — the v0.1.2
+  anchor `f"/whisper-{model}"` silently broke for the `-mlx`-suffixed
+  repos (`base`, `small`, `medium`, `large-v3`): a cache populated
+  with `mlx-community/whisper-large-v3-mlx` does not end with
+  `/whisper-large-v3`, so AC-US-5.2's silence path was bypassed on
+  every warm run for those four shortnames — the user got an
+  `event=model_download` notice on every invocation even though
+  the model was already on disk. Re-anchored on
+  `f"/{leaf-of-resolved-repo}"` so the cache check and the build
+  path agree on which repo backs each shortname
+  (`src/podcast_script/backends/mlx.py`).
+
+### Maintainer runbook
+
+- **After upstream Whisper adds a new shortname** that is added to
+  `config.SUPPORTED_MODELS` — probe the HuggingFace API for the
+  canonical mlx-community conversion and add a row to
+  `_CANONICAL_MLX_REPOS` in the same commit:
+
+  ```sh
+  for repo in \
+      mlx-community/whisper-<shortname> \
+      mlx-community/whisper-<shortname>-mlx; do
+      printf '%-50s %s\n' "$repo" \
+          "$(curl -s -o /dev/null -w '%{http_code}' \
+              "https://huggingface.co/api/models/${repo}")"
+  done
+  ```
+
+  The `200` row is the canonical name. If both return `200`, prefer
+  the unsuffixed form for cache continuity with prior releases
+  (per the `tiny` precedent). If neither returns `200`, the
+  shortname has not been converted to MLX format yet — do not add
+  to the table and document the gap in the README's model-size
+  table.
 
 ## [0.1.2] - 2026-05-02
 

--- a/src/podcast_script/backends/mlx.py
+++ b/src/podcast_script/backends/mlx.py
@@ -32,28 +32,69 @@ from .base import TranscribedSegment, emit_first_run_notice_if_missing
 
 _log = logging.getLogger(__name__)
 
-_MLX_COMMUNITY_PREFIX = "mlx-community/whisper-"
-"""Canonical HuggingFace org + repo prefix for the mlx-whisper conversions.
+_CANONICAL_MLX_REPOS: dict[str, str] = {
+    # Verified against `https://huggingface.co/api/models/<repo>` on
+    # 2026-05-02. The mlx-community org applies the ``-mlx`` suffix
+    # asymmetrically — ``tiny`` ships under both `whisper-tiny` and
+    # `whisper-tiny-mlx`, ``large-v3-turbo`` ships only without the
+    # suffix, and the rest are ``-mlx``-only. The v0.1.2 prefix-rule
+    # fix (`mlx-community/whisper-{model}` for every shortname) 404'd
+    # on `base`, `small`, `medium`, `large-v3` because those repos
+    # only exist with the suffix; the inverse rule (always append
+    # `-mlx`) would 404 on `large-v3-turbo`. Explicit table is the
+    # only way the matrix closes (issue #45 v2).
+    #
+    # ``tiny`` deliberately maps to the unsuffixed repo to match the
+    # cache convention seeded by every prior release — flipping it to
+    # ``-mlx`` would re-trigger a download notice for users who
+    # already have ``mlx-community/whisper-tiny`` on disk.
+    "tiny": "mlx-community/whisper-tiny",
+    "base": "mlx-community/whisper-base-mlx",
+    "small": "mlx-community/whisper-small-mlx",
+    "medium": "mlx-community/whisper-medium-mlx",
+    "large-v3": "mlx-community/whisper-large-v3-mlx",
+    "large-v3-turbo": "mlx-community/whisper-large-v3-turbo",
+}
+"""Shortname → canonical ``mlx-community`` HF repo id mapping.
 
-``mlx_whisper.load_models.load_model`` resolves its argument as either a
-local filesystem path or a fully-qualified HF repo id — bare Whisper
-shortnames like ``"large-v3"`` 404 on the HF API. Aligns with
-:meth:`MlxWhisperBackend._is_cached`'s ``/whisper-{model}`` anchor so
-the cache-lookup and download paths agree on which repo backs each
-shortname (issue #45).
+Mirrors :data:`podcast_script.config.SUPPORTED_MODELS`. When a future
+Whisper variant lands and is added to ``SUPPORTED_MODELS``, the
+maintainer probes the HF API and adds a row here in the same commit
+— see the runbook entry in ``CHANGELOG.md`` ``### Maintainer runbook``.
+"""
+
+_MLX_COMMUNITY_PREFIX = "mlx-community/whisper-"
+"""Best-effort prefix for shortnames not in :data:`_CANONICAL_MLX_REPOS`.
+
+Forward-compat fallback only — keeps the door open for a
+``--model <new-shortname>`` that landed in upstream Whisper but has not
+yet been added to the canonical table. Users hitting this branch get
+the same 404 they would have on v0.1.2 if mlx-community has not
+converted the model; intentional, since the alternative is hard-coding
+"likely" naming and silently misdirecting the download.
 """
 
 
 def _resolve_repo_id(model: str) -> str:
     """Map a Whisper shortname (``large-v3``) to its mlx-community repo id.
 
-    Idempotent: a value that already looks like a path or repo id (i.e.
-    contains ``"/"``) passes through unchanged. This keeps the door open
-    for a power-user override (``--model mlx-community/whisper-large-v3-q4``
-    or a local fine-tune path) without re-prefixing.
+    Three branches:
+
+    1. **Pass-through** for anything containing ``"/"`` — already a
+       fully-qualified HF repo id (``mlx-community/whisper-large-v3-q4``)
+       or a local filesystem path. The power-user override surface.
+    2. **Canonical table lookup** for the v1-supported shortnames in
+       :data:`_CANONICAL_MLX_REPOS`. The naming asymmetry across the
+       mlx-community org (some models ``-mlx``-suffixed, some not) is
+       too irregular for a prefix rule.
+    3. **Best-effort prefix** for unknown shortnames — same shape as
+       the v0.1.2 fallback. Forward-compat for shortnames added to
+       upstream Whisper after this release.
     """
     if "/" in model:
         return model
+    if model in _CANONICAL_MLX_REPOS:
+        return _CANONICAL_MLX_REPOS[model]
     return f"{_MLX_COMMUNITY_PREFIX}{model}"
 
 
@@ -171,13 +212,24 @@ class MlxWhisperBackend:
         """Return ``True`` if an mlx-whisper cache entry for ``model`` exists.
 
         Real path: lazy-imports ``huggingface_hub`` and scans the local
-        cache for any repo whose id ends with ``/whisper-{model}``. The
-        leading slash is load-bearing — it disambiguates ``mlx-community``
-        repos (``mlx-community/whisper-tiny``) from the faster-whisper
+        cache for any repo whose id ends with ``/<leaf>`` where
+        ``<leaf>`` is the basename of the resolved repo id from
+        :func:`_resolve_repo_id` (e.g. ``whisper-large-v3-mlx`` for
+        shortname ``large-v3``, ``whisper-large-v3-turbo`` for
+        ``large-v3-turbo``). The leading slash is load-bearing — it
+        disambiguates ``mlx-community`` repos from the faster-whisper
         siblings (``Systran/faster-whisper-tiny``) that share the same
         ``~/.cache/huggingface`` directory. Without the slash anchor,
         a faster cache entry would falsely report the mlx model as
         cached and silently suppress the AC-US-5.1 notice.
+
+        The previous v0.1.2 implementation hard-coded the anchor as
+        ``f"/whisper-{model}"`` — which silently broke for the
+        ``-mlx``-suffixed repos (``base``, ``small``, ``medium``,
+        ``large-v3``): a cache populated with
+        ``mlx-community/whisper-large-v3-mlx`` does not end with
+        ``/whisper-large-v3``, so AC-US-5.2's silence path was bypassed
+        on every warm run for those four shortnames (issue #45 v2).
 
         Override-point for unit tests — POD-030 (Tier 2, SP-6) covers
         the live HF surface on macOS CI.
@@ -195,7 +247,8 @@ class MlxWhisperBackend:
             info = scan_cache_dir()
         except Exception:
             return False
-        target = f"/whisper-{model}"
+        leaf = _resolve_repo_id(model).rsplit("/", 1)[-1]
+        target = f"/{leaf}"
         return any(repo.repo_id.endswith(target) for repo in info.repos)
 
     def _build_model(self, model: str, device: str) -> object:

--- a/tests/unit/test_mlx_backend.py
+++ b/tests/unit/test_mlx_backend.py
@@ -460,8 +460,10 @@ def test_default_is_cached_uses_huggingface_hub_scan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Real ``_is_cached`` path: stub ``huggingface_hub.scan_cache_dir``
-    to return a synthetic cache containing ``mlx-community/whisper-large-v3``
-    and assert :meth:`_is_cached` returns ``True`` for ``large-v3`` and
+    to return a synthetic cache containing
+    ``mlx-community/whisper-large-v3-mlx`` (the actual repo backing the
+    ``large-v3`` shortname per the canonical table — issue #45 v2) and
+    assert :meth:`_is_cached` returns ``True`` for ``large-v3`` and
     ``False`` for ``tiny`` (not in the synthetic cache). The real lib is
     consulted only here — POD-030 (Tier 2) covers the live HF surface.
     """
@@ -474,7 +476,7 @@ def test_default_is_cached_uses_huggingface_hub_scan(
         def __init__(self, repos: list[_FakeRepo]) -> None:
             self.repos = repos
 
-    fake_cache = _FakeCacheInfo([_FakeRepo("mlx-community/whisper-large-v3")])
+    fake_cache = _FakeCacheInfo([_FakeRepo("mlx-community/whisper-large-v3-mlx")])
 
     import huggingface_hub
 
@@ -497,18 +499,34 @@ def test_default_is_cached_uses_huggingface_hub_scan(
         # caches even though both live under ~/.cache/huggingface.
         ("Systran/faster-whisper-tiny", "tiny", False),
         ("Systran/faster-whisper-large-v3", "large-v3", False),
-        # Canonical mlx-community repos MUST match the bare model name —
-        # this is the AC-US-5.2 silence path.
+        # Canonical mlx-community repos per the issue #45 v2 table MUST
+        # match — this is the AC-US-5.2 silence path. Anchor is the
+        # leaf of the resolved repo id, not ``whisper-{shortname}``,
+        # because the v0.1.2 fix's ``/whisper-{model}`` rule failed to
+        # match the actual ``-mlx``-suffixed repos for `base`, `small`,
+        # `medium`, `large-v3` (ref CHANGELOG `[0.1.3]`).
         ("mlx-community/whisper-tiny", "tiny", True),
-        ("mlx-community/whisper-large-v3", "large-v3", True),
+        ("mlx-community/whisper-base-mlx", "base", True),
+        ("mlx-community/whisper-small-mlx", "small", True),
+        ("mlx-community/whisper-medium-mlx", "medium", True),
+        ("mlx-community/whisper-large-v3-mlx", "large-v3", True),
         ("mlx-community/whisper-large-v3-turbo", "large-v3-turbo", True),
-        # Owner forks of an mlx-community model MUST also match (any
-        # owner/<...>/whisper-{model} suffix is valid).
-        ("some-fork/whisper-large-v3", "large-v3", True),
-        # Bare model requested, only a quantised variant cached: the
-        # bare model is genuinely missing on disk so the notice MUST
-        # fire — anchoring on ``/whisper-{model}`` keeps this False.
+        # The wrong-name v0.1.2 cache shape MUST NOT match anymore —
+        # ``mlx-community/whisper-large-v3`` doesn't actually exist on
+        # HF, but if a user manually populated a cache entry under
+        # that name (e.g. mid-failed-download from v0.1.2), it should
+        # not silently satisfy the AC-US-5.2 silence path for the now
+        # correctly-resolved ``-mlx`` repo.
+        ("mlx-community/whisper-large-v3", "large-v3", False),
+        # Owner forks of an mlx-community repo MUST also match the
+        # canonical leaf — the ``-mlx`` suffix is part of the actual
+        # repo name, not a synthesised tag.
+        ("some-fork/whisper-large-v3-mlx", "large-v3", True),
+        # Bare shortname requested, only a quantised variant cached:
+        # the canonical repo is genuinely missing on disk so the
+        # notice MUST fire — leaf anchor keeps this False.
         ("mlx-community/whisper-tiny-q4", "tiny", False),
+        ("mlx-community/whisper-large-v3-mlx-q4", "large-v3", False),
     ],
 )
 def test_default_is_cached_anchors_match_on_end_of_repo_id(
@@ -519,9 +537,12 @@ def test_default_is_cached_anchors_match_on_end_of_repo_id(
 ) -> None:
     """Same anchor-on-end discipline as faster's ``_is_cached`` (ref:
     PR #12 review): a substring match would let the faster-whisper repos
-    falsely report their mlx counterparts as cached. Anchoring on the
-    full ``/whisper-{model}`` suffix disambiguates the two backends'
-    caches sharing ``~/.cache/huggingface``.
+    falsely report their mlx counterparts as cached. The leaf anchor
+    (``f"/{leaf-of-resolved-repo}"``) disambiguates the two backends'
+    caches sharing ``~/.cache/huggingface`` AND covers the issue #45 v2
+    naming asymmetry — ``base``/``small``/``medium``/``large-v3`` cache
+    under ``-mlx``-suffixed leaves, ``tiny``/``large-v3-turbo`` under
+    bare leaves.
     """
 
     class _FakeRepo:
@@ -570,20 +591,36 @@ def test_default_is_cached_returns_false_when_scan_fails(
 @pytest.mark.parametrize(
     ("model", "expected"),
     [
+        # Canonical mapping — verified against
+        # ``https://huggingface.co/api/models/<repo>`` on 2026-05-02.
+        # The mlx-community org applies the ``-mlx`` suffix
+        # asymmetrically: ``tiny`` exists under both `whisper-tiny` and
+        # `whisper-tiny-mlx`, ``large-v3-turbo`` ships only without the
+        # suffix, the rest are ``-mlx``-only. The v0.1.2 prefix-rule
+        # fix 404'd on `base`, `small`, `medium`, `large-v3`; the
+        # inverse rule would 404 on `large-v3-turbo` (issue #45 v2).
         ("tiny", "mlx-community/whisper-tiny"),
-        ("base", "mlx-community/whisper-base"),
-        ("small", "mlx-community/whisper-small"),
-        ("medium", "mlx-community/whisper-medium"),
-        ("large-v3", "mlx-community/whisper-large-v3"),
+        ("base", "mlx-community/whisper-base-mlx"),
+        ("small", "mlx-community/whisper-small-mlx"),
+        ("medium", "mlx-community/whisper-medium-mlx"),
+        ("large-v3", "mlx-community/whisper-large-v3-mlx"),
         ("large-v3-turbo", "mlx-community/whisper-large-v3-turbo"),
-        # Idempotent on already-prefixed repo ids — keeps the door open
-        # for power-user overrides (community quants, local fine-tunes)
-        # without re-prefixing.
-        ("mlx-community/whisper-large-v3", "mlx-community/whisper-large-v3"),
+        # Idempotent on already-qualified repo ids — keeps the door
+        # open for power-user overrides (community quants, local
+        # fine-tunes) without re-prefixing.
+        ("mlx-community/whisper-large-v3-mlx", "mlx-community/whisper-large-v3-mlx"),
         ("mlx-community/whisper-large-v3-q4", "mlx-community/whisper-large-v3-q4"),
         ("some-fork/whisper-tiny", "some-fork/whisper-tiny"),
         # Local filesystem path passes through (any ``/`` short-circuits).
         ("/tmp/whisper-fine-tune", "/tmp/whisper-fine-tune"),
+        # Forward-compat fallback for shortnames not in the canonical
+        # table — preserves the v0.1.2 ``mlx-community/whisper-{model}``
+        # shape so a future Whisper variant added to upstream can be
+        # tried without a code change. Best-effort only; if the org
+        # has not converted that variant yet the user gets the same
+        # 404 as v0.1.2 (intentional — alternative is silent
+        # misdirection).
+        ("v4-experimental", "mlx-community/whisper-v4-experimental"),
     ],
 )
 def test_resolve_repo_id_maps_bare_shortname_to_mlx_community_issue_45(
@@ -593,10 +630,11 @@ def test_resolve_repo_id_maps_bare_shortname_to_mlx_community_issue_45(
     local path or a fully-qualified HF repo id — bare shortnames like
     ``"large-v3"`` 404 with ``RepositoryNotFoundError: 401 …``. The
     backend's ``_build_model`` MUST normalise via :func:`_resolve_repo_id`
-    so the user-facing ``--model large-v3`` shortname resolves to the
-    canonical ``mlx-community/whisper-large-v3`` HF repo before the
-    download path runs. Anything containing ``"/"`` (already-qualified
-    repo id, local path) passes through unchanged.
+    using the explicit canonical-table for v1-supported shortnames
+    (the ``-mlx`` suffix is not uniform across mlx-community), with a
+    best-effort prefix fallback for forward-compat. Anything containing
+    ``"/"`` (already-qualified repo id, local path) passes through
+    unchanged.
     """
     assert _resolve_repo_id(model) == expected
 
@@ -623,8 +661,8 @@ def test_load_passes_resolved_repo_id_to_build_model_issue_45() -> None:
     backend = _CapturingBackend()
     backend.load(model="large-v3", device="cpu")
 
-    assert captured == ["mlx-community/whisper-large-v3"]
-    assert backend._model_name == "mlx-community/whisper-large-v3", (
+    assert captured == ["mlx-community/whisper-large-v3-mlx"]
+    assert backend._model_name == "mlx-community/whisper-large-v3-mlx", (
         "_model_name must store the resolved repo id so _run_inference's "
         "path_or_hf_repo arg targets the actual HF repo, not the bare shortname"
     )


### PR DESCRIPTION
Re-fix for #45 — the v0.1.2 patch was still 404ing for the dogfooder reporter.

## Summary

- The v0.1.2 fix used a uniform `mlx-community/whisper-{shortname}` prefix rule which **still 404'd** on `base`, `small`, `medium`, and `large-v3` because the mlx-community org applies the `-mlx` suffix asymmetrically. Verified against the HuggingFace API on 2026-05-02:

  | shortname | `whisper-<name>` | `whisper-<name>-mlx` |
  |---|---|---|
  | `tiny` | 200 | 200 |
  | `base` | **401** | 200 |
  | `small` | **401** | 200 |
  | `medium` | 307 → `whisper-medium-mlx-4bit` (a 4-bit quant) | 200 |
  | `large-v3` | **401** ← user-reported | 200 |
  | `large-v3-turbo` | 200 | **401** |

  No prefix rule can close the matrix. The inverse rule (always append `-mlx`) would break `large-v3-turbo`. Replaced with an explicit `_CANONICAL_MLX_REPOS` table; best-effort `mlx-community/whisper-{shortname}` fallback retained for unknown shortnames so future Whisper additions don't require a code change in the common case.
- Same naming asymmetry also broke `_is_cached` — the v0.1.2 anchor `f\"/whisper-{model}\"` doesn't match a cache populated with `mlx-community/whisper-large-v3-mlx`, so AC-US-5.2's silence path was bypassed on every warm run for `base`/`small`/`medium`/`large-v3`. Re-anchored on `f\"/{leaf-of-resolved-repo}\"` so cache check and build path agree.
- Added a `### Maintainer runbook` entry for \"After upstream Whisper adds a new shortname\" — embeds the curl probe loop and the unsuffixed-vs-suffixed precedence rule (`tiny` precedent for cache continuity).

## What changed

| File | Why |
|---|---|
| `src/podcast_script/backends/mlx.py` | Replace `_MLX_COMMUNITY_PREFIX` with `_CANONICAL_MLX_REPOS` table; add forward-compat fallback; re-anchor `_is_cached` on resolved-repo leaf |
| `tests/unit/test_mlx_backend.py` | Parametrized `_resolve_repo_id` table reflects canonical mapping; `_is_cached` parametrized cases re-anchor on real repo leaves; existing synthetic cache fixed to use the actual `-mlx`-suffixed repo |
| `CHANGELOG.md` | `[Unreleased]` `### Fixed` + `### Maintainer runbook` |

## SemVer impact

Patch — no contract changes. The five SRS §16.1 contracts (Markdown shape, 8-code `--lang` set, exit codes, logfmt + 22-token catalogue, CLI grammar) are byte-identical to v0.1.2.

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy` — clean (44 source files, strict)
- [x] `uv run pytest tests/unit -q` — 271 passed (was 265 — 6 new parametrized cases for the canonical-table + leaf-anchor invariants)
- [x] `uv run pytest tests/contract -q -m contract` — 21 passed
- [x] `uv run pytest tests/integration -q -m \"slow or not slow\"` — 6 passed
- [x] HF API spot-check — `mlx-community/whisper-large-v3-mlx` ships `weights.npz` + `config.json` (the MLX-format file pair `mlx_whisper.load_model` expects)
- [ ] **Live verification on dogfooder's machine** — once tagged, the original reporter (#45) re-runs `--model large-v3` and confirms the download succeeds

Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)