### PR TITLE
chore: cut v0.1.3 — patch release for issue #45 re-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ major-version bump per SemVer.
 
 ## [Unreleased]
 
+_(no entries yet — post-v0.1.3 work lands here.)_
+
+## [0.1.3] - 2026-05-02
+
+Patch release per SemVer 2.0.0 §4. No API changes; delta is the
+single PR (#48) re-fixing issue #45 — the v0.1.2 fix had used a
+uniform `mlx-community/whisper-{shortname}` prefix rule which still
+404'd on `base`, `small`, `medium`, and `large-v3` (those shortnames
+are only published under the `-mlx` suffix). Reported again by the
+same dogfooder same day. The five `SRS.md` §16.1 contracts (output
+Markdown shape, 8-code `--lang` set, exit codes, logfmt format +
+22-token catalogue, CLI grammar) are byte-identical to v0.1.2. Cut
+so the dogfooder workflow's `--model large-v3` path actually works
+end-to-end before more invitations go out.
+
 ### Fixed
 
 - **Issue #45 (re-fix)** — the v0.1.2 fix used a uniform
@@ -611,6 +626,20 @@ happen.
   on macOS arm64 CPU) so dogfooders pinning to the guide URL get a
   working `--model large-v3` path and a clean stderr stream. No CI
   gate change vs. v0.1.1; same Ubuntu + macOS-14 matrix.
+- **v0.1.3 — actual 2026-05-02; not projected.** Same-day third
+  patch release after v0.1.2, re-fixing issue #45 — the v0.1.2 fix
+  had used a uniform `mlx-community/whisper-{shortname}` prefix
+  rule which still 404'd on `base`, `small`, `medium`, `large-v3`
+  (those shortnames are only published in the mlx-community org
+  under the `-mlx` suffix). The naming asymmetry was not visible
+  to v0.1.2's pre-merge testing: the `tiny`-only end-to-end
+  verification ran against a shortname that does happen to ship
+  under both forms, masking the bug for every other shortname.
+  v0.1.3's tests probe the canonical-repo table directly +
+  parametrize over all six v1-supported shortnames; future
+  shortname additions trip the new `### Maintainer runbook` entry
+  rather than landing silently. Same no-projection framing as
+  v0.1.1 / v0.1.2; no CI gate change vs. v0.1.2.
 
 ### Risk-register churn
 

--- a/README.md
+++ b/README.md
@@ -372,12 +372,12 @@ The architecture lives in
 
 ## For invited dogfooders
 
-If you've been invited to test `v0.1.2` ahead of the `v1.0.0` cut —
+If you've been invited to test `v0.1.3` ahead of the `v1.0.0` cut —
 welcome, and read [`docs/DOGFOODING.md`](docs/DOGFOODING.md) first.
 It walks through what's being asked (~30–60 minute commitment), the
 Q7 success bar (run the README quickstart on your own audio without
 needing maintainer help), and how to file feedback that actually
-moves the project forward. Pin your clone to the `v0.1.2` tag, not
+moves the project forward. Pin your clone to the `v0.1.3` tag, not
 `main`, so every dogfooder is testing the same surface.
 
 ## License

--- a/docs/DOGFOODING.md
+++ b/docs/DOGFOODING.md
@@ -1,6 +1,6 @@
-# Dogfooding `podcast-script` v0.1.2
+# Dogfooding `podcast-script` v0.1.3
 
-You've been invited to test `v0.1.2` ahead of the `v1.0.0` release. This
+You've been invited to test `v0.1.3` ahead of the `v1.0.0` release. This
 guide walks you through what's being asked, what the success bar looks
 like, and how to file feedback that actually moves the project forward.
 
@@ -23,7 +23,7 @@ need to DM the maintainer to make the tool work, that's a doc bug.
   10–30 minute MP3 / audio file from a podcast you've worked on.
 - **Where feedback goes.** GitHub Issues — `https://github.com/invaderDMG/podcast-script/issues`. No DMs, no email, no
   surveys (per `PROJECT_BRIEF.md` §17).
-- **Your tag is `v0.1.2`.** Not `main`. Pinning to the tag means
+- **Your tag is `v0.1.3`.** Not `main`. Pinning to the tag means
   every dogfooder is testing the exact same surface and your feedback
   is comparable.
 
@@ -78,10 +78,10 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 brew install ffmpeg              # macOS
 sudo apt-get install ffmpeg      # Debian / Ubuntu
 
-# (3) the project itself. Pin to v0.1.2 — not main.
+# (3) the project itself. Pin to v0.1.3 — not main.
 git clone https://github.com/invaderDMG/podcast-script.git
 cd podcast-script
-git checkout v0.1.2              # important — pin the surface
+git checkout v0.1.3              # important — pin the surface
 uv sync                          # creates .venv with locked deps
 ```
 
@@ -260,7 +260,7 @@ For anything that crashed or misbehaved, include:
 - Python: <output of `python3 --version`>
 - uv: <output of `uv --version`>
 - ffmpeg: <output of `ffmpeg -version | head -1`>
-- Project version: v0.1.2 (commit <output of `git rev-parse HEAD`>)
+- Project version: v0.1.3 (commit <output of `git rev-parse HEAD`>)
 
 ## Reproduction
 The exact CLI invocation:
@@ -347,7 +347,7 @@ Per `PROJECT_PLAN.md` §8, the dogfooder phase passes when *"at least
 one external dogfooder has run the quickstart end-to-end without
 help, before the v1.0.0 tag"*. Concretely:
 
-- ✅ **Pass:** you cloned the repo at `v0.1.2`, ran `uv sync`, ran
+- ✅ **Pass:** you cloned the repo at `v0.1.3`, ran `uv sync`, ran
   the quickstart on your own audio, got a transcript out, and filed
   at least one issue (positive or negative). You did this without
   needing to DM the maintainer.
@@ -397,7 +397,7 @@ If you (the maintainer) are reading this, here's a copy-paste-ready
 DM for inviting a dogfooder. Replace `{NAME}` with their name and
 adjust as needed:
 
-> Hey {NAME} — I just shipped `v0.1.2` of a small CLI tool I've been
+> Hey {NAME} — I just shipped `v0.1.3` of a small CLI tool I've been
 > building, `podcast-script`. It segments podcast audio into speech
 > vs. music regions and runs Whisper only on the speech (so no
 > hallucinated "lyrics" over your music beds). I'm looking for one
@@ -409,8 +409,8 @@ adjust as needed:
 > found.
 >
 > Repo + dogfooder guide:
-> https://github.com/invaderDMG/podcast-script/blob/v0.1.2/docs/DOGFOODING.md
+> https://github.com/invaderDMG/podcast-script/blob/v0.1.3/docs/DOGFOODING.md
 >
-> Pin to the `v0.1.2` tag so everyone's testing the same surface.
+> Pin to the `v0.1.3` tag so everyone's testing the same surface.
 > No worries if it's not your week — saying so is more useful than
 > committing and ghosting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "podcast-script"
-version = "0.1.2"
+version = "0.1.3"
 description = "Transcribe podcasts to Markdown with music segment markers."
 requires-python = ">=3.12"
 authors = [{ name = "Juan García" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1708,7 +1708,7 @@ wheels = [
 
 [[package]]
 name = "podcast-script"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
## Summary
- **v0.1.3 patch release.** Bundles PR #48 (the re-fix for issue #45 — v0.1.2's uniform `mlx-community/whisper-{shortname}` prefix rule still 404'd on `base`, `small`, `medium`, `large-v3` because the org applies the `-mlx` suffix asymmetrically) into a tagged release the dogfooder DM-template URL resolves under.
- Pure release-prep diff: CHANGELOG promotion + version bump + DM-template URL refresh. Zero source / test / config touched.
- After this PR squash-merges, the `v0.1.3` tag lands as a separate confirmation gate, then the GitHub Release.

## What's in v0.1.3 vs. v0.1.2
One PR in the delta:

| PR | Type | What |
|---|---|---|
| #48 | Fixed | Re-fix for #45 — replace prefix rule with explicit `_CANONICAL_MLX_REPOS` table; re-anchor `_is_cached` on resolved-repo leaf; new `### Maintainer runbook` entry with the curl probe loop |

**No API changes.** The five SRS §16.1 contracts (Markdown shape, 8-code `--lang`, exit codes, logfmt + 22-token catalogue, CLI grammar) are byte-identical to v0.1.2.

## Acceptance criteria (PR scope)
- [x] **AC-1** — `pyproject.toml` version flipped `0.1.2` → `0.1.3`. `uv lock` re-resolved cleanly (120 packages; only local-package self-version line).
- [x] **AC-2** — CHANGELOG `[Unreleased]` content (the #45 v2 fix bullets + maintainer-runbook entry that landed via PR #48) promoted to `## [0.1.3] - 2026-05-02`; fresh empty `[Unreleased]` placeholder.
- [x] **AC-3** — `### Schedule slippage` fourth entry: v0.1.3 actual 2026-05-02, "not projected" framing + one-sentence note on why v0.1.2's pre-merge testing missed the asymmetry.
- [x] **AC-4** — `docs/DOGFOODING.md` 10 `v0.1.2` references → `v0.1.3`.
- [x] **AC-5** — `README.md` `## For invited dogfooders` paragraph's two `v0.1.2` references → `v0.1.3`.

## Acceptance criteria deferred to post-merge
- [ ] **AC-6** — `v0.1.3` annotated tag pushed to origin pointing at this PR's squash-merge SHA.
- [ ] **AC-7** — GitHub Release published against the `v0.1.3` tag (matching the v0.1.2 pattern just established).

## Test plan
- [x] `uv lock` → 120 packages; only local-package self-version line changed.
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run mypy` — clean (44 files, strict).
- [x] `uv run pytest tests/unit -q` — 271 passed.
- [ ] CI matrix (`ubuntu-24.04` + `macos-14`): expected green; same coverage as v0.1.2 cut.

## Tagging plan (post-merge)
After this PR squash-merges:

```sh
git checkout main && git pull --ff-only
git tag -a v0.1.3 -m "v0.1.3 — patch: re-fix #45 (mlx canonical-repo table)"
git push origin v0.1.3
gh release create v0.1.3 --title "v0.1.3 — patch: re-fix #45 (mlx canonical-repo table)" --latest --verify-tag --notes "..."
```

Refs PR #48 (the re-fix), v0.1.2 cut (PR #47), Keep-a-Changelog 1.1.0, SemVer 2.0.0 §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)